### PR TITLE
[#7] 오토 레이아웃을 쉽게 작성할 수 있는 코드를 작성한다

### DIFF
--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -13,6 +13,12 @@
 		9B289C772BDCED27000813C1 /* LaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C762BDCED27000813C1 /* LaunchViewController.swift */; };
 		9B289C792BDCED2C000813C1 /* LaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C782BDCED2C000813C1 /* LaunchView.swift */; };
 		9B289C7B2BDCF0E0000813C1 /* LayoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C7A2BDCF0E0000813C1 /* LayoutViewController.swift */; };
+		9B289C7E2BDD34B7000813C1 /* AutoLayoutWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C7D2BDD34B7000813C1 /* AutoLayoutWrapper.swift */; };
+		9B289C802BDD34E1000813C1 /* AutoLayoutWrapper+Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C7F2BDD34E1000813C1 /* AutoLayoutWrapper+Size.swift */; };
+		9B289C822BDD3B6C000813C1 /* AutoLayoutWrapper+Center.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C812BDD3B6C000813C1 /* AutoLayoutWrapper+Center.swift */; };
+		9B289C842BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C832BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift */; };
+		9B289C862BDD3BA4000813C1 /* AutoLayoutWrapper+Horizontal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C852BDD3BA4000813C1 /* AutoLayoutWrapper+Horizontal.swift */; };
+		9B289C882BDD3C03000813C1 /* AutoLayoutWrapper+All.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C872BDD3C03000813C1 /* AutoLayoutWrapper+All.swift */; };
 		9B4581222BD52EB7002A32DC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4581212BD52EB7002A32DC /* AppDelegate.swift */; };
 		9B4581242BD52EB7002A32DC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4581232BD52EB7002A32DC /* SceneDelegate.swift */; };
 		9B45812C2BD52EB7002A32DC /* RefactorMoti.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 9B45812A2BD52EB7002A32DC /* RefactorMoti.xcdatamodeld */; };
@@ -53,6 +59,12 @@
 		9B289C762BDCED27000813C1 /* LaunchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewController.swift; sourceTree = "<group>"; };
 		9B289C782BDCED2C000813C1 /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchView.swift; sourceTree = "<group>"; };
 		9B289C7A2BDCF0E0000813C1 /* LayoutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutViewController.swift; sourceTree = "<group>"; };
+		9B289C7D2BDD34B7000813C1 /* AutoLayoutWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLayoutWrapper.swift; sourceTree = "<group>"; };
+		9B289C7F2BDD34E1000813C1 /* AutoLayoutWrapper+Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayoutWrapper+Size.swift"; sourceTree = "<group>"; };
+		9B289C812BDD3B6C000813C1 /* AutoLayoutWrapper+Center.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayoutWrapper+Center.swift"; sourceTree = "<group>"; };
+		9B289C832BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayoutWrapper+Vertical.swift"; sourceTree = "<group>"; };
+		9B289C852BDD3BA4000813C1 /* AutoLayoutWrapper+Horizontal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayoutWrapper+Horizontal.swift"; sourceTree = "<group>"; };
+		9B289C872BDD3C03000813C1 /* AutoLayoutWrapper+All.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayoutWrapper+All.swift"; sourceTree = "<group>"; };
 		9B45811E2BD52EB7002A32DC /* RefactorMoti.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RefactorMoti.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B4581212BD52EB7002A32DC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9B4581232BD52EB7002A32DC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -113,6 +125,19 @@
 				9B289C7A2BDCF0E0000813C1 /* LayoutViewController.swift */,
 			);
 			path = Base;
+			sourceTree = "<group>";
+		};
+		9B289C7C2BDD3368000813C1 /* AutoLayout */ = {
+			isa = PBXGroup;
+			children = (
+				9B289C7D2BDD34B7000813C1 /* AutoLayoutWrapper.swift */,
+				9B289C7F2BDD34E1000813C1 /* AutoLayoutWrapper+Size.swift */,
+				9B289C812BDD3B6C000813C1 /* AutoLayoutWrapper+Center.swift */,
+				9B289C832BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift */,
+				9B289C852BDD3BA4000813C1 /* AutoLayoutWrapper+Horizontal.swift */,
+				9B289C872BDD3C03000813C1 /* AutoLayoutWrapper+All.swift */,
+			);
+			path = AutoLayout;
 			sourceTree = "<group>";
 		};
 		9B4581152BD52EB7002A32DC = {
@@ -190,6 +215,7 @@
 		9B45815F2BD7EA26002A32DC /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				9B289C7C2BDD3368000813C1 /* AutoLayout */,
 				9B289C712BDCDDB5000813C1 /* Base */,
 				9B4581872BD936BE002A32DC /* Launch */,
 			);
@@ -424,8 +450,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B289C802BDD34E1000813C1 /* AutoLayoutWrapper+Size.swift in Sources */,
 				9B289C752BDCE249000813C1 /* BaseViewController.swift in Sources */,
+				9B289C7E2BDD34B7000813C1 /* AutoLayoutWrapper.swift in Sources */,
 				9B289C7B2BDCF0E0000813C1 /* LayoutViewController.swift in Sources */,
+				9B289C842BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift in Sources */,
 				9B289C792BDCED2C000813C1 /* LaunchView.swift in Sources */,
 				9B45816C2BD7EAED002A32DC /* VersionRepository.swift in Sources */,
 				9B45812C2BD52EB7002A32DC /* RefactorMoti.xcdatamodeld in Sources */,
@@ -435,8 +464,11 @@
 				9B4581832BD9341A002A32DC /* FirebaseStorageProtocol.swift in Sources */,
 				9B4581702BD7EB37002A32DC /* FirebaseStorage.swift in Sources */,
 				9B45816A2BD7EAE7002A32DC /* VersionRepositoryProtocol.swift in Sources */,
+				9B289C822BDD3B6C000813C1 /* AutoLayoutWrapper+Center.swift in Sources */,
 				9B45818C2BD936DB002A32DC /* LaunchViewModel.swift in Sources */,
+				9B289C862BDD3BA4000813C1 /* AutoLayoutWrapper+Horizontal.swift in Sources */,
 				9B4581902BD93D3F002A32DC /* LaunchViewModelProtocol.swift in Sources */,
+				9B289C882BDD3C03000813C1 /* AutoLayoutWrapper+All.swift in Sources */,
 				9B4581802BD92FED002A32DC /* FetchVersionUseCase.swift in Sources */,
 				9B4581782BD7EF2F002A32DC /* Version.swift in Sources */,
 				9B4581242BD52EB7002A32DC /* SceneDelegate.swift in Sources */,

--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		9B289C6C2BDBD4E1000813C1 /* AuthUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C6B2BDBD4E1000813C1 /* AuthUseCaseTests.swift */; };
-		9B289C702BDCD350000813C1 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 9B289C6F2BDCD350000813C1 /* SnapKit */; };
 		9B289C732BDCDDBD000813C1 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C722BDCDDBD000813C1 /* BaseView.swift */; };
 		9B289C752BDCE249000813C1 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C742BDCE249000813C1 /* BaseViewController.swift */; };
 		9B289C772BDCED27000813C1 /* LaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C762BDCED27000813C1 /* LaunchViewController.swift */; };
@@ -85,7 +84,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9B4581742BD7EC40002A32DC /* FirebaseDatabase in Frameworks */,
-				9B289C702BDCD350000813C1 /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -313,7 +311,6 @@
 			name = RefactorMoti;
 			packageProductDependencies = (
 				9B4581732BD7EC40002A32DC /* FirebaseDatabase */,
-				9B289C6F2BDCD350000813C1 /* SnapKit */,
 			);
 			productName = RefactorMoti;
 			productReference = 9B45811E2BD52EB7002A32DC /* RefactorMoti.app */;
@@ -368,7 +365,6 @@
 			mainGroup = 9B4581152BD52EB7002A32DC;
 			packageReferences = (
 				9B4581722BD7EC40002A32DC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
-				9B289C6E2BDCD350000813C1 /* XCRemoteSwiftPackageReference "SnapKit" */,
 			);
 			productRefGroup = 9B45811F2BD52EB7002A32DC /* Products */;
 			projectDirPath = "";
@@ -741,14 +737,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		9B289C6E2BDCD350000813C1 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/SnapKit/SnapKit";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.7.1;
-			};
-		};
 		9B4581722BD7EC40002A32DC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
@@ -760,11 +748,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		9B289C6F2BDCD350000813C1 /* SnapKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9B289C6E2BDCD350000813C1 /* XCRemoteSwiftPackageReference "SnapKit" */;
-			productName = SnapKit;
-		};
 		9B4581732BD7EC40002A32DC /* FirebaseDatabase */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 9B4581722BD7EC40002A32DC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper+All.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper+All.swift
@@ -1,0 +1,37 @@
+//
+//  AutoLayoutWrapper+All.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 4/27/24.
+//
+
+import UIKit
+
+extension AutoLayoutWrapper {
+
+    // MARK: - All
+
+    @discardableResult
+    func all(equalTo basedView: UIView, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: basedView.topAnchor, constant: constant),
+            view.bottomAnchor.constraint(equalTo: basedView.bottomAnchor, constant: -constant),
+            view.leftAnchor.constraint(equalTo: basedView.leftAnchor, constant: constant),
+            view.rightAnchor.constraint(equalTo: basedView.rightAnchor, constant: -constant)
+        ])
+        return self
+    }
+    
+    @discardableResult
+    func all(equalTo safeAreaGuide: UILayoutGuide, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: safeAreaGuide.topAnchor, constant: constant),
+            view.bottomAnchor.constraint(equalTo: safeAreaGuide.bottomAnchor, constant: -constant),
+            view.leftAnchor.constraint(equalTo: safeAreaGuide.leftAnchor, constant: constant),
+            view.rightAnchor.constraint(equalTo: safeAreaGuide.rightAnchor, constant: -constant)
+        ])
+        return self
+    }
+}

--- a/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper+Center.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper+Center.swift
@@ -1,0 +1,77 @@
+//
+//  AutoLayoutWrapper+Center.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 4/27/24.
+//
+
+import UIKit
+
+extension AutoLayoutWrapper {
+    
+    // MARK: - Center
+    
+    @discardableResult
+    func center(equalTo basedView: UIView) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.centerXAnchor.constraint(equalTo: basedView.centerXAnchor).isActive = true
+        view.centerYAnchor.constraint(equalTo: basedView.centerYAnchor).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func center(equalTo safeAreaGuide: UILayoutGuide) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.centerXAnchor.constraint(equalTo: safeAreaGuide.centerXAnchor).isActive = true
+        view.centerYAnchor.constraint(equalTo: safeAreaGuide.centerYAnchor).isActive = true
+        return self
+    }
+    
+    
+    // MARK: - Center X
+    
+    @discardableResult
+    func centerX(equalTo anchor: XAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.centerXAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func centerX(greaterThanOrEqualTo anchor: XAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.centerXAnchor.constraint(greaterThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func centerX(lessThanOrEqualTo anchor: XAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.centerXAnchor.constraint(lessThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    
+    // MARK: - Center Y
+    
+    @discardableResult
+    func centerY(equalTo anchor: YAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.centerYAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func centerY(greaterThanOrEqualTo anchor: YAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.centerYAnchor.constraint(greaterThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func centerY(lessThanOrEqualTo anchor: YAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.centerYAnchor.constraint(lessThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+}

--- a/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper+Horizontal.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper+Horizontal.swift
@@ -1,0 +1,77 @@
+//
+//  AutoLayoutWrapper+Horizontal.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 4/27/24.
+//
+
+import UIKit
+
+extension AutoLayoutWrapper {
+
+    // MARK: - Horizontal
+
+    @discardableResult
+    func horizontal(equalTo basedView: UIView, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.leftAnchor.constraint(equalTo: basedView.leftAnchor, constant: constant).isActive = true
+        view.rightAnchor.constraint(equalTo: basedView.rightAnchor, constant: -constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func horizontal(equalTo safeAreaGuide: UILayoutGuide, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.leftAnchor.constraint(equalTo: safeAreaGuide.leftAnchor, constant: constant).isActive = true
+        view.rightAnchor.constraint(equalTo: safeAreaGuide.rightAnchor, constant: -constant).isActive = true
+        return self
+    }
+    
+    
+    // MARK: - Left
+    
+    @discardableResult
+    func left(equalTo anchor: XAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.leftAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func left(greaterThanOrEqualTo anchor: XAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.leftAnchor.constraint(greaterThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func left(lessThanOrEqualTo anchor: XAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.leftAnchor.constraint(lessThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    
+    // MARK: - Right
+    
+    @discardableResult
+    func right(equalTo anchor: XAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.rightAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func right(greaterThanOrEqualTo anchor: XAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.rightAnchor.constraint(greaterThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func right(lessThanOrEqualTo anchor: XAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.rightAnchor.constraint(lessThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+}

--- a/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper+Size.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper+Size.swift
@@ -12,10 +12,10 @@ extension AutoLayoutWrapper {
     // MARK: - Size
     
     @discardableResult
-    func size(width: CGFloat, height: CGFloat) -> Self {
+    func size(_ size: CGSize) -> Self {
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.widthAnchor.constraint(equalToConstant: width).isActive = true
-        view.heightAnchor.constraint(equalToConstant: height).isActive = true
+        view.widthAnchor.constraint(equalToConstant: size.width).isActive = true
+        view.heightAnchor.constraint(equalToConstant: size.height).isActive = true
         return self
     }
     

--- a/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper+Size.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper+Size.swift
@@ -1,0 +1,55 @@
+//
+//  AutoLayoutWrapper+Size.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 4/27/24.
+//
+
+import UIKit
+
+extension AutoLayoutWrapper {
+
+    // MARK: - Size
+    
+    @discardableResult
+    func size(width: CGFloat, height: CGFloat) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.widthAnchor.constraint(equalToConstant: width).isActive = true
+        view.heightAnchor.constraint(equalToConstant: height).isActive = true
+        return self
+    }
+    
+    
+    // MARK: - Width
+    
+    @discardableResult
+    func width(equalTo anchor: Dimension, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.widthAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func width(_ constant: CGFloat) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.widthAnchor.constraint(equalToConstant: constant).isActive = true
+        return self
+    }
+    
+    
+    // MARK: - Height
+    
+    @discardableResult
+    func height(equalTo anchor: Dimension, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.heightAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func height(_ constant: CGFloat) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.heightAnchor.constraint(equalToConstant: constant).isActive = true
+        return self
+    }
+}

--- a/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper+Vertical.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper+Vertical.swift
@@ -1,0 +1,77 @@
+//
+//  AutoLayoutWrapper+Vertical.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 4/27/24.
+//
+
+import UIKit
+
+extension AutoLayoutWrapper {
+    
+    // MARK: - Vertical
+    
+    @discardableResult
+    func vertical(equalTo basedView: UIView, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.topAnchor.constraint(equalTo: basedView.topAnchor, constant: constant).isActive = true
+        view.bottomAnchor.constraint(equalTo: basedView.bottomAnchor, constant: -constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func vertical(equalTo safeAreaGuide: UILayoutGuide, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.topAnchor.constraint(equalTo: safeAreaGuide.topAnchor, constant: constant).isActive = true
+        view.bottomAnchor.constraint(equalTo: safeAreaGuide.bottomAnchor, constant: -constant).isActive = true
+        return self
+    }
+    
+    
+    // MARK: - Top
+    
+    @discardableResult
+    func top(equalTo anchor: YAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.topAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func top(greaterThanOrEqualTo anchor: YAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.topAnchor.constraint(greaterThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func top(lessThanOrEqualTo anchor: YAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.topAnchor.constraint(lessThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    
+    // MARK: - Bottom
+    
+    @discardableResult
+    func bottom(equalTo anchor: YAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.bottomAnchor.constraint(equalTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func bottom(greaterThanOrEqualTo anchor: YAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.bottomAnchor.constraint(greaterThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    func bottom(lessThanOrEqualTo anchor: YAnchor, constant: CGFloat = 0) -> Self {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.bottomAnchor.constraint(lessThanOrEqualTo: anchor, constant: constant).isActive = true
+        return self
+    }
+}

--- a/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/AutoLayout/AutoLayoutWrapper.swift
@@ -1,0 +1,31 @@
+//
+//  AutoLayoutWrapper.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 4/27/24.
+//
+
+import UIKit
+
+struct AutoLayoutWrapper {
+    
+    typealias Dimension = NSLayoutAnchor<NSLayoutDimension>
+    typealias XAnchor = NSLayoutAnchor<NSLayoutXAxisAnchor>
+    typealias YAnchor = NSLayoutAnchor<NSLayoutYAxisAnchor>
+    
+    let view: UIView
+}
+
+protocol AutoLayoutCompatible: UIView {
+
+    var atl: AutoLayoutWrapper { get }
+}
+
+extension AutoLayoutCompatible {
+
+    var atl: AutoLayoutWrapper {
+        AutoLayoutWrapper(view: self)
+    }
+}
+
+extension UIView: AutoLayoutCompatible { }

--- a/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchView.swift
@@ -35,19 +35,13 @@ final class LaunchView: BaseView {
     }
     
     override func setUpConstraint() {
-        motiIconImageView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            motiIconImageView.widthAnchor.constraint(equalToConstant: Size.appIconRound.width),
-            motiIconImageView.heightAnchor.constraint(equalToConstant: Size.appIconRound.height),
-            motiIconImageView.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor),
-            motiIconImageView.centerYAnchor.constraint(equalTo: safeAreaLayoutGuide.centerYAnchor)
-        ])
+        motiIconImageView.atl
+            .size(Size.appIconRound)
+            .center(equalTo: safeAreaLayoutGuide)
         
-        versionLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            versionLabel.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor),
-            versionLabel.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Metric.VersionLabel.bottomOffset)
-        ])
+        versionLabel.atl
+            .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
+            .bottom(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Metric.VersionLabel.bottomOffset)
     }
 }
 

--- a/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchView.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import SnapKit
 
 final class LaunchView: BaseView {
     
@@ -36,14 +35,19 @@ final class LaunchView: BaseView {
     }
     
     override func setUpConstraint() {
-        motiIconImageView.snp.makeConstraints {
-            $0.size.equalTo(Size.appIconRound)
-            $0.center.equalToSuperview()
-        }
-        versionLabel.snp.makeConstraints {
-            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).offset(-Metric.VersionLabel.bottomOffset)
-            $0.centerX.equalToSuperview()
-        }
+        motiIconImageView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            motiIconImageView.widthAnchor.constraint(equalToConstant: Size.appIconRound.width),
+            motiIconImageView.heightAnchor.constraint(equalToConstant: Size.appIconRound.height),
+            motiIconImageView.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor),
+            motiIconImageView.centerYAnchor.constraint(equalTo: safeAreaLayoutGuide.centerYAnchor)
+        ])
+        
+        versionLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            versionLabel.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor),
+            versionLabel.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Metric.VersionLabel.bottomOffset)
+        ])
     }
 }
 
@@ -56,7 +60,7 @@ private extension LaunchView {
         
         enum VersionLabel {
             
-            static let bottomOffset = 20
+            static let bottomOffset: CGFloat = 20
         }
     }
     


### PR DESCRIPTION
## Overview
- 오토 레이아웃을 쉽게 작성할 수 있는 Extension을 구현하였습니다.
  - UIView에서 atl 참조를 통해 여러 오토레이아웃 메서드를 호출할 수 있습니다.
  - 선언형 프로그래밍처럼 내부 코드를 몰라도 명확하게 사용할 수 있습니다.

- Snapkit 의존성을 제거하였습니다.
- Snapkit으로 구현되어 있던 기존 LaunchView를 ATL로 변환하였습니다.

## 보강해야 할 점
- 현재 구현은 Constraint 업데이트가 불가합니다.
- moti 2.0에서는 불필요하지만 어떻게 구현할 수 있을지 고민하고 있습니다.

## Issue
closed #7 
