### PR TITLE
[#16, #18] Login 화면 UI를 구현한다.

### DIFF
--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		9B289C842BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C832BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift */; };
 		9B289C862BDD3BA4000813C1 /* AutoLayoutWrapper+Horizontal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C852BDD3BA4000813C1 /* AutoLayoutWrapper+Horizontal.swift */; };
 		9B289C882BDD3C03000813C1 /* AutoLayoutWrapper+All.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C872BDD3C03000813C1 /* AutoLayoutWrapper+All.swift */; };
+		9B289C8B2BDE4682000813C1 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C8A2BDE4682000813C1 /* LoginView.swift */; };
+		9B289C8D2BDE4687000813C1 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B289C8C2BDE4687000813C1 /* LoginViewController.swift */; };
 		9B4581222BD52EB7002A32DC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4581212BD52EB7002A32DC /* AppDelegate.swift */; };
 		9B4581242BD52EB7002A32DC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4581232BD52EB7002A32DC /* SceneDelegate.swift */; };
 		9B45812C2BD52EB7002A32DC /* RefactorMoti.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 9B45812A2BD52EB7002A32DC /* RefactorMoti.xcdatamodeld */; };
@@ -65,6 +67,8 @@
 		9B289C832BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayoutWrapper+Vertical.swift"; sourceTree = "<group>"; };
 		9B289C852BDD3BA4000813C1 /* AutoLayoutWrapper+Horizontal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayoutWrapper+Horizontal.swift"; sourceTree = "<group>"; };
 		9B289C872BDD3C03000813C1 /* AutoLayoutWrapper+All.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutoLayoutWrapper+All.swift"; sourceTree = "<group>"; };
+		9B289C8A2BDE4682000813C1 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		9B289C8C2BDE4687000813C1 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		9B45811E2BD52EB7002A32DC /* RefactorMoti.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RefactorMoti.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B4581212BD52EB7002A32DC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9B4581232BD52EB7002A32DC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -138,6 +142,15 @@
 				9B289C872BDD3C03000813C1 /* AutoLayoutWrapper+All.swift */,
 			);
 			path = AutoLayout;
+			sourceTree = "<group>";
+		};
+		9B289C892BDE466B000813C1 /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				9B289C8A2BDE4682000813C1 /* LoginView.swift */,
+				9B289C8C2BDE4687000813C1 /* LoginViewController.swift */,
+			);
+			path = Login;
 			sourceTree = "<group>";
 		};
 		9B4581152BD52EB7002A32DC = {
@@ -218,6 +231,7 @@
 				9B289C7C2BDD3368000813C1 /* AutoLayout */,
 				9B289C712BDCDDB5000813C1 /* Base */,
 				9B4581872BD936BE002A32DC /* Launch */,
+				9B289C892BDE466B000813C1 /* Login */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -454,6 +468,7 @@
 				9B289C752BDCE249000813C1 /* BaseViewController.swift in Sources */,
 				9B289C7E2BDD34B7000813C1 /* AutoLayoutWrapper.swift in Sources */,
 				9B289C7B2BDCF0E0000813C1 /* LayoutViewController.swift in Sources */,
+				9B289C8B2BDE4682000813C1 /* LoginView.swift in Sources */,
 				9B289C842BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift in Sources */,
 				9B289C792BDCED2C000813C1 /* LaunchView.swift in Sources */,
 				9B45816C2BD7EAED002A32DC /* VersionRepository.swift in Sources */,
@@ -461,6 +476,7 @@
 				9B4581222BD52EB7002A32DC /* AppDelegate.swift in Sources */,
 				9B289C732BDCDDBD000813C1 /* BaseView.swift in Sources */,
 				9B289C772BDCED27000813C1 /* LaunchViewController.swift in Sources */,
+				9B289C8D2BDE4687000813C1 /* LoginViewController.swift in Sources */,
 				9B4581832BD9341A002A32DC /* FirebaseStorageProtocol.swift in Sources */,
 				9B4581702BD7EB37002A32DC /* FirebaseStorage.swift in Sources */,
 				9B45816A2BD7EAE7002A32DC /* VersionRepositoryProtocol.swift in Sources */,

--- a/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchView.swift
@@ -23,7 +23,11 @@ final class LaunchView: BaseView {
         view.image = UIImage(resource: .appIconRound)
         return view
     }()
-    private let versionLabel: UILabel = UILabel()
+    private let versionLabel: UILabel = {
+        let label = UILabel()
+        label.text = Text.waitingVersion
+        return label
+    }()
     
     
     // MARK: - Setup
@@ -64,5 +68,10 @@ private extension LaunchView {
     enum Size {
         
         static let appIconRound = CGSize(width: 120, height: 120)
+    }
+    
+    enum Text {
+        
+        static let waitingVersion = "버전을 가져오는 중"
     }
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchViewController.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchViewController.swift
@@ -47,6 +47,26 @@ private extension LaunchViewController {
                 layoutView.update(currentVersion: currentVersion)
             }
             .store(in: &cancellables)
+        output.canLaunch
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in
+                guard let self else { return }
+                moveToLoginViewController()
+            }
+            .store(in: &cancellables)
+    }
+}
+
+
+// MARK: - Move To LoginViewController
+
+private extension LaunchViewController {
+    
+    func moveToLoginViewController() {
+        let loginVC = LoginViewController()
+        loginVC.modalPresentationStyle = .fullScreen
+        dismiss(animated: false)
+        present(loginVC, animated: false)
     }
 }
 

--- a/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchViewModel.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchViewModel.swift
@@ -54,6 +54,7 @@ private extension LaunchViewModel {
             
             let compareResult = version.current.compare(version.forced, options: .numeric)
             if compareResult == .orderedDescending {
+                try? await Task.sleep(nanoseconds: UInt64(1 * 1_000_000_000))
                 output.canLaunch.send()
             } else {
                 output.isNeedForcedUpdate.send()

--- a/RefactorMoti/RefactorMoti/Presentation/Login/LoginView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Login/LoginView.swift
@@ -1,0 +1,73 @@
+//
+//  LoginView.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 4/28/24.
+//
+
+import UIKit
+
+final class LoginView: BaseView {
+    
+    // MARK: - UI
+    
+    private let motiIconImageView: UIImageView = {
+        let view = UIImageView()
+        view.image = UIImage(resource: .appIconRound)
+        return view
+    }()
+    private let loginButton: UIButton = {
+        let button = UIButton()
+        var configuration = UIButton.Configuration.filled()
+        configuration.title = Text.login
+        configuration.baseBackgroundColor = .lightGray
+        button.configuration = configuration
+        return button
+    }()
+    
+    
+    // MARK: - Setup
+    
+    override func setUpAttribute() {
+        backgroundColor = .systemBackground
+    }
+    
+    override func setUpSubview() {
+        addSubview(motiIconImageView)
+        addSubview(loginButton)
+    }
+    
+    override func setUpConstraint() {
+        motiIconImageView.atl
+            .size(Size.appIconRound)
+            .center(equalTo: safeAreaLayoutGuide)
+        loginButton.atl
+            .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
+            .horizontal(equalTo: safeAreaLayoutGuide, constant: Metric.LoginButton.offset)
+            .bottom(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Metric.LoginButton.offset)
+    }
+}
+
+
+// MARK: - Constant
+
+private extension LoginView {
+    
+    enum Metric {
+        
+        enum LoginButton {
+            
+            static let offset: CGFloat = 20
+        }
+    }
+    
+    enum Size {
+        
+        static let appIconRound = CGSize(width: 120, height: 120)
+    }
+    
+    enum Text {
+        
+        static let login = "로그인"
+    }
+}

--- a/RefactorMoti/RefactorMoti/Presentation/Login/LoginViewController.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Login/LoginViewController.swift
@@ -1,0 +1,10 @@
+//
+//  LoginViewController.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 4/28/24.
+//
+
+import UIKit
+
+final class LoginViewController: LayoutViewController<LoginView> { }


### PR DESCRIPTION
## Overview
- Login 화면 UI를 구현하였습니다.
  - 현재는 임의 버튼을 통해 무조건 로그인 성공 처리를 할 것입니다.
  - 애플 로그인 + 파이어베이스 인증을 넣을 예정입니다.
- Launch 화면에서 1초 후 Login 화면으로 이동하게 하였습니다.

## Screenshot
<img src = "https://github.com/jeongju9216/moti-2.0/assets/89075274/5add3669-758d-4f19-b546-42a1542860fb" width = "40%">

## Issue
closed #16
closed #18
