### PR TITLE
[#20] 강제 업데이트 기준을 변경, 방출하는 타입을 Bool로 변경

### DIFF
--- a/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchViewController.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchViewController.swift
@@ -49,9 +49,11 @@ private extension LaunchViewController {
             .store(in: &cancellables)
         output.canLaunch
             .receive(on: RunLoop.main)
-            .sink { [weak self] in
+            .sink { [weak self] canLaunch in
                 guard let self else { return }
-                moveToLoginViewController()
+                if canLaunch {
+                    moveToLoginViewController()
+                }
             }
             .store(in: &cancellables)
     }

--- a/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchViewModel.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchViewModel.swift
@@ -53,11 +53,12 @@ private extension LaunchViewModel {
             output.currentVersion.send(version.current)
             
             let compareResult = version.current.compare(version.forced, options: .numeric)
-            if compareResult == .orderedDescending {
-                try? await Task.sleep(nanoseconds: UInt64(1 * 1_000_000_000))
-                output.canLaunch.send()
+            let isNeedForcedUpdate = (compareResult == .orderedAscending)
+            if isNeedForcedUpdate {
+                output.isNeedForcedUpdate.send(true)
             } else {
-                output.isNeedForcedUpdate.send()
+                try? await Task.sleep(nanoseconds: 1 * 1_000_000_000)
+                output.canLaunch.send(true)
             }
         }
     }

--- a/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchViewModelProtocol.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchViewModelProtocol.swift
@@ -18,8 +18,8 @@ extension LaunchViewModel {
     struct Output {
         
         let currentVersion: PassthroughSubject<String, Never> = .init()
-        let canLaunch: PassthroughSubject<Void, Never> = .init()
-        let isNeedForcedUpdate: PassthroughSubject<Void, Never> = .init()
+        let canLaunch: PassthroughSubject<Bool, Never> = .init()
+        let isNeedForcedUpdate: PassthroughSubject<Bool, Never> = .init()
     }
 }
 

--- a/RefactorMoti/RefactorMotiTests/Launch/LaunchViewModelTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Launch/LaunchViewModelTests.swift
@@ -46,7 +46,7 @@ final class LaunchViewModelTests: XCTestCase {
             .store(in: &cancellables)
 
         // then
-        wait(for: [expectation], timeout: 5)
+        wait(for: [expectation], timeout: 10)
         
         XCTAssertNotNil(version)
         XCTAssertEqual(version, "1.0.0")
@@ -66,8 +66,8 @@ final class LaunchViewModelTests: XCTestCase {
         var isNeedForcedUpdate = false
         input.viewDidLoad.send()
         viewModel.output.isNeedForcedUpdate
-            .sink {
-                isNeedForcedUpdate = true
+            .sink { value in
+                isNeedForcedUpdate = value
                 expectation.fulfill()
             }
             .store(in: &cancellables)
@@ -77,7 +77,7 @@ final class LaunchViewModelTests: XCTestCase {
         XCTAssertTrue(isNeedForcedUpdate)
     }
     
-    func test_given_현재버전과_강제업데이트버전이_존재할_때_when_현재버전이_강제업데이트버전과_같다면_then_업데이트가_필요하다() throws {
+    func test_given_현재버전과_강제업데이트버전이_존재할_때_when_현재버전이_강제업데이트버전과_같다면_then_true_launch가_가능하다() throws {
         // given
         let expectation = XCTestExpectation()
         let usecase = FetchVersionUseCaseStub(current: "1.0.0", forced: "1.0.0")
@@ -86,18 +86,18 @@ final class LaunchViewModelTests: XCTestCase {
         viewModel.bind(input: input)
         
         // when
-        var isNeedForcedUpdate = false
         input.viewDidLoad.send()
-        viewModel.output.isNeedForcedUpdate
-            .sink {
-                isNeedForcedUpdate = true
+        var canLaunch = false
+        viewModel.output.canLaunch
+            .sink { value in
+                canLaunch = value
                 expectation.fulfill()
             }
             .store(in: &cancellables)
 
         // then
         wait(for: [expectation], timeout: 5)
-        XCTAssertTrue(isNeedForcedUpdate)
+        XCTAssertTrue(canLaunch)
     }
     
     func test_given_현재버전과_강제업데이트버전이_존재할_때_when_현재버전이_강제업데이트버전_초과라면_then_true_launch가_가능하다() throws {
@@ -107,13 +107,13 @@ final class LaunchViewModelTests: XCTestCase {
         let viewModel = LaunchViewModel(fetchVersionUseCase: usecase)
         let input = LaunchViewModel.Input()
         viewModel.bind(input: input)
-        
+
         // when
-        var canLaunch = false
         input.viewDidLoad.send()
+        var canLaunch = false
         viewModel.output.canLaunch
-            .sink {
-                canLaunch = true
+            .sink { value in
+                canLaunch = value
                 expectation.fulfill()
             }
             .store(in: &cancellables)

--- a/RefactorMoti/RefactorMotiTests/Launch/LaunchViewModelTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Launch/LaunchViewModelTests.swift
@@ -15,6 +15,7 @@ final class LaunchViewModelTests: XCTestCase {
     
     private var cancellables: Set<AnyCancellable> = []
     
+    
     // MARK: - Life Cycle
     
     override func tearDown() {
@@ -33,18 +34,19 @@ final class LaunchViewModelTests: XCTestCase {
         let viewModel = LaunchViewModel(fetchVersionUseCase: usecase)
         let input = LaunchViewModel.Input()
         viewModel.bind(input: input)
-        input.viewDidLoad.send()
         
         // when
         var version: String? = nil
+        input.viewDidLoad.send()
         viewModel.output.currentVersion
-            .receive(on: RunLoop.main)
-            .sink { currentVersion in
-                version = currentVersion
+            .sink(receiveCompletion: { completion in
                 expectation.fulfill()
-            }
+            }, receiveValue: { value in
+                version = value
+                expectation.fulfill()
+            })
             .store(in: &cancellables)
-
+        
         // then
         wait(for: [expectation], timeout: 10)
         


### PR DESCRIPTION
## Overview
- 강제 업데이트 기준을 변경하였습니다. (#20 참고)
- canLaunch, isNeedForcedUpdate의 방출 타입을 Bool로 변경
  - 명확한 처리를 위해 Bool로 처리하고, 로직을 구현하였습니다.

## Issue
closed #20 
