### PR TITLE
[#47] FetchCategoryUseCase를 구현한다. + Note

### DIFF
--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -59,11 +59,14 @@
 		9BA895A22BE390F90080D400 /* AchievementRepositoryStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895A12BE390F90080D400 /* AchievementRepositoryStub.swift */; };
 		9BA895A42BE5131D0080D400 /* FetchAchievementsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895A32BE5131D0080D400 /* FetchAchievementsUseCaseTests.swift */; };
 		9BA895A62BE519420080D400 /* FetchAchievementsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895A52BE519420080D400 /* FetchAchievementsUseCase.swift */; };
+		9BA895A82BE520B90080D400 /* HomeViewModelInputOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895A72BE520B90080D400 /* HomeViewModelInputOutput.swift */; };
+		9BA895AA2BE520CD0080D400 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895A92BE520CD0080D400 /* HomeViewModel.swift */; };
 		9BA895AC2BE5EEF20080D400 /* FetchCategoriesUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895AB2BE5EEF20080D400 /* FetchCategoriesUseCaseTests.swift */; };
 		9BA895B22BE5F42A0080D400 /* CategoryRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895B12BE5F42A0080D400 /* CategoryRepositoryTests.swift */; };
 		9BA895B42BE5F6E10080D400 /* CategoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895B32BE5F6E10080D400 /* CategoryRepository.swift */; };
 		9BA895B62BE5F6E80080D400 /* CategoryRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895B52BE5F6E80080D400 /* CategoryRepositoryProtocol.swift */; };
 		9BA895B82BE5F87D0080D400 /* CategoryRepositoryStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895B72BE5F87D0080D400 /* CategoryRepositoryStub.swift */; };
+		9BA895BA2BE5FBC50080D400 /* FetchCategoriesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895B92BE5FBC50080D400 /* FetchCategoriesUseCase.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -130,11 +133,14 @@
 		9BA895A12BE390F90080D400 /* AchievementRepositoryStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepositoryStub.swift; sourceTree = "<group>"; };
 		9BA895A32BE5131D0080D400 /* FetchAchievementsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAchievementsUseCaseTests.swift; sourceTree = "<group>"; };
 		9BA895A52BE519420080D400 /* FetchAchievementsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAchievementsUseCase.swift; sourceTree = "<group>"; };
+		9BA895A72BE520B90080D400 /* HomeViewModelInputOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelInputOutput.swift; sourceTree = "<group>"; };
+		9BA895A92BE520CD0080D400 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		9BA895AB2BE5EEF20080D400 /* FetchCategoriesUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchCategoriesUseCaseTests.swift; sourceTree = "<group>"; };
 		9BA895B12BE5F42A0080D400 /* CategoryRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRepositoryTests.swift; sourceTree = "<group>"; };
 		9BA895B32BE5F6E10080D400 /* CategoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRepository.swift; sourceTree = "<group>"; };
 		9BA895B52BE5F6E80080D400 /* CategoryRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRepositoryProtocol.swift; sourceTree = "<group>"; };
 		9BA895B72BE5F87D0080D400 /* CategoryRepositoryStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRepositoryStub.swift; sourceTree = "<group>"; };
+		9BA895B92BE5FBC50080D400 /* FetchCategoriesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchCategoriesUseCase.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -214,6 +220,8 @@
 			children = (
 				9B411CBE2BDFD0A700A50B78 /* HomeViewController.swift */,
 				9B411CC02BDFD0AC00A50B78 /* HomeView.swift */,
+				9BA895A72BE520B90080D400 /* HomeViewModelInputOutput.swift */,
+				9BA895A92BE520CD0080D400 /* HomeViewModel.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -365,6 +373,7 @@
 			children = (
 				9B45817F2BD92FED002A32DC /* FetchVersionUseCase.swift */,
 				9BA895A52BE519420080D400 /* FetchAchievementsUseCase.swift */,
+				9BA895B92BE5FBC50080D400 /* FetchCategoriesUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -627,9 +636,11 @@
 				9B289C7B2BDCF0E0000813C1 /* LayoutViewController.swift in Sources */,
 				9BA8959F2BE38D6A0080D400 /* Achievement.swift in Sources */,
 				9B411CBF2BDFD0A700A50B78 /* HomeViewController.swift in Sources */,
+				9BA895BA2BE5FBC50080D400 /* FetchCategoriesUseCase.swift in Sources */,
 				9B289C8B2BDE4682000813C1 /* LoginView.swift in Sources */,
 				9B289C842BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift in Sources */,
 				9B289C792BDCED2C000813C1 /* LaunchView.swift in Sources */,
+				9BA895AA2BE520CD0080D400 /* HomeViewModel.swift in Sources */,
 				9B45816C2BD7EAED002A32DC /* VersionRepository.swift in Sources */,
 				9B411CB32BDFC31F00A50B78 /* LoginViewModel.swift in Sources */,
 				9B45812C2BD52EB7002A32DC /* RefactorMoti.xcdatamodeld in Sources */,
@@ -656,6 +667,7 @@
 				9BA895B42BE5F6E10080D400 /* CategoryRepository.swift in Sources */,
 				9BA895A62BE519420080D400 /* FetchAchievementsUseCase.swift in Sources */,
 				9BA8959B2BE38CCA0080D400 /* AchievementRepository.swift in Sources */,
+				9BA895A82BE520B90080D400 /* HomeViewModelInputOutput.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -59,8 +59,6 @@
 		9BA895A22BE390F90080D400 /* AchievementRepositoryStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895A12BE390F90080D400 /* AchievementRepositoryStub.swift */; };
 		9BA895A42BE5131D0080D400 /* FetchAchievementsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895A32BE5131D0080D400 /* FetchAchievementsUseCaseTests.swift */; };
 		9BA895A62BE519420080D400 /* FetchAchievementsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895A52BE519420080D400 /* FetchAchievementsUseCase.swift */; };
-		9BA895A82BE520B90080D400 /* HomeViewModelInputOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895A72BE520B90080D400 /* HomeViewModelInputOutput.swift */; };
-		9BA895AA2BE520CD0080D400 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895A92BE520CD0080D400 /* HomeViewModel.swift */; };
 		9BA895AC2BE5EEF20080D400 /* FetchCategoriesUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895AB2BE5EEF20080D400 /* FetchCategoriesUseCaseTests.swift */; };
 		9BA895B22BE5F42A0080D400 /* CategoryRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895B12BE5F42A0080D400 /* CategoryRepositoryTests.swift */; };
 		9BA895B42BE5F6E10080D400 /* CategoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895B32BE5F6E10080D400 /* CategoryRepository.swift */; };
@@ -133,8 +131,6 @@
 		9BA895A12BE390F90080D400 /* AchievementRepositoryStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepositoryStub.swift; sourceTree = "<group>"; };
 		9BA895A32BE5131D0080D400 /* FetchAchievementsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAchievementsUseCaseTests.swift; sourceTree = "<group>"; };
 		9BA895A52BE519420080D400 /* FetchAchievementsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAchievementsUseCase.swift; sourceTree = "<group>"; };
-		9BA895A72BE520B90080D400 /* HomeViewModelInputOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelInputOutput.swift; sourceTree = "<group>"; };
-		9BA895A92BE520CD0080D400 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		9BA895AB2BE5EEF20080D400 /* FetchCategoriesUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchCategoriesUseCaseTests.swift; sourceTree = "<group>"; };
 		9BA895B12BE5F42A0080D400 /* CategoryRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRepositoryTests.swift; sourceTree = "<group>"; };
 		9BA895B32BE5F6E10080D400 /* CategoryRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRepository.swift; sourceTree = "<group>"; };
@@ -220,8 +216,6 @@
 			children = (
 				9B411CBE2BDFD0A700A50B78 /* HomeViewController.swift */,
 				9B411CC02BDFD0AC00A50B78 /* HomeView.swift */,
-				9BA895A72BE520B90080D400 /* HomeViewModelInputOutput.swift */,
-				9BA895A92BE520CD0080D400 /* HomeViewModel.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -640,7 +634,6 @@
 				9B289C8B2BDE4682000813C1 /* LoginView.swift in Sources */,
 				9B289C842BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift in Sources */,
 				9B289C792BDCED2C000813C1 /* LaunchView.swift in Sources */,
-				9BA895AA2BE520CD0080D400 /* HomeViewModel.swift in Sources */,
 				9B45816C2BD7EAED002A32DC /* VersionRepository.swift in Sources */,
 				9B411CB32BDFC31F00A50B78 /* LoginViewModel.swift in Sources */,
 				9B45812C2BD52EB7002A32DC /* RefactorMoti.xcdatamodeld in Sources */,
@@ -667,7 +660,6 @@
 				9BA895B42BE5F6E10080D400 /* CategoryRepository.swift in Sources */,
 				9BA895A62BE519420080D400 /* FetchAchievementsUseCase.swift in Sources */,
 				9BA8959B2BE38CCA0080D400 /* AchievementRepository.swift in Sources */,
-				9BA895A82BE520B90080D400 /* HomeViewModelInputOutput.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RefactorMoti/RefactorMoti/Domain/UseCase/FetchCategoriesUseCase.swift
+++ b/RefactorMoti/RefactorMoti/Domain/UseCase/FetchCategoriesUseCase.swift
@@ -1,0 +1,34 @@
+//
+//  FetchCategoriesUseCase.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 5/4/24.
+//
+
+import Foundation
+
+protocol FetchCategoriesUseCaseProtocol {
+    
+    func execute() async throws -> [String]
+}
+
+struct FetchCategoriesUseCase: FetchCategoriesUseCaseProtocol {
+    
+    // MARK: - Interface
+    
+    func execute() async throws -> [String] {
+        try await repository.fetchCategories()
+    }
+    
+    
+    // MARK: - Attribute
+    
+    private let repository: CategoryRepositoryProtocol
+    
+    
+    // MARK: - Initializer
+    
+    init(repository: CategoryRepositoryProtocol = CategoryRepository()) {
+        self.repository = repository
+    }
+}

--- a/RefactorMoti/RefactorMotiTests/Domain/UseCase/FetchCategoriesUseCaseTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Domain/UseCase/FetchCategoriesUseCaseTests.swift
@@ -6,12 +6,36 @@
 //
 
 import XCTest
+@testable import RefactorMoti
 
 final class FetchCategoriesUseCaseTests: XCTestCase {
 
-    func test_데이터가_있을_때_fetchCategories_수행이_성공하면_category_리스트를_반환한다() async throws { }
+    private let defaultCategories = ["전체", "미설정"]
+    private let customCategory = "음식"
     
-    func test_데이터가_없을_때_fetchCategories_수행이_성공하면_빈_리스트를_반환한다() async throws { }
+    func test_기본_카테고리만_있을_때_fetchCategories_수행이_성공하면_기본_리스트를_반환한다() async throws { 
+        // given
+        let usecase = FetchCategoriesUseCase(repository: DefaultCategoryRepositoryStub())
+        
+        // when
+        let categories = try? await usecase.execute()
+        
+        // then
+        XCTAssertNotNil(categories)
+        XCTAssertEqual(categories, defaultCategories)
+    }
+    
+    func test_사용자가_추가한_카테고리가_있을_때_fetchCategories_수행에_성공하면_category_리스트를_반환한다() async throws {
+        // given
+        let usecase = FetchCategoriesUseCase(repository: CustomCategoryRepositoryStub())
+        
+        // when
+        let categories = try? await usecase.execute()
+        
+        // then
+        XCTAssertNotNil(categories)
+        XCTAssertEqual(categories, defaultCategories + [customCategory])
+    }
     
     func test_fetchCategories_수행에_실패하면_에러를_발생시킨다() async throws { }
 }


### PR DESCRIPTION
## Overview
FetchCategoryUseCase를 구현하였습니다.

## 노트
이 과정에서 Cherry Pick을 처음 사용해 보았습니다.
#44 구현 브랜치에 이어서 #47 브랜치를 만드는 바람에 커밋을 분리할 수 없었습니다.
Cherry Pick을 사용하여 이 문제를 해결했고 #47 작업만 남길 수 있었습니다.
커밋을 다른 브랜치로 이동시킨다는 개념이 생소했지만 좋은 경험이었습니다.

## Issue
closed #47 
