### PR TITLE
[#50] CategoryItem Entity를 정의한다. + Note

### DIFF
--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		9BA895BA2BE5FBC50080D400 /* FetchCategoriesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895B92BE5FBC50080D400 /* FetchCategoriesUseCase.swift */; };
 		9BA895C02BE604DA0080D400 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895BF2BE604DA0080D400 /* HomeViewModel.swift */; };
 		9BA895C22BE604E90080D400 /* HomeViewModelInputOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895C12BE604E90080D400 /* HomeViewModelInputOutput.swift */; };
+		9BA895C92BE673120080D400 /* CategoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895C82BE673120080D400 /* CategoryItem.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -141,6 +142,7 @@
 		9BA895B92BE5FBC50080D400 /* FetchCategoriesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchCategoriesUseCase.swift; sourceTree = "<group>"; };
 		9BA895BF2BE604DA0080D400 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		9BA895C12BE604E90080D400 /* HomeViewModelInputOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelInputOutput.swift; sourceTree = "<group>"; };
+		9BA895C82BE673120080D400 /* CategoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryItem.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -364,6 +366,7 @@
 			children = (
 				9B4581772BD7EF2F002A32DC /* Version.swift */,
 				9BA8959E2BE38D6A0080D400 /* Achievement.swift */,
+				9BA895C82BE673120080D400 /* CategoryItem.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -654,6 +657,7 @@
 				9B4581702BD7EB37002A32DC /* FirebaseStorage.swift in Sources */,
 				9B45816A2BD7EAE7002A32DC /* VersionRepositoryProtocol.swift in Sources */,
 				9B289C822BDD3B6C000813C1 /* AutoLayoutWrapper+Center.swift in Sources */,
+				9BA895C92BE673120080D400 /* CategoryItem.swift in Sources */,
 				9B45818C2BD936DB002A32DC /* LaunchViewModel.swift in Sources */,
 				9B289C862BDD3BA4000813C1 /* AutoLayoutWrapper+Horizontal.swift in Sources */,
 				9B4581902BD93D3F002A32DC /* LaunchViewModelProtocol.swift in Sources */,

--- a/RefactorMoti/RefactorMoti/Data/Repository/AchievementRepository.swift
+++ b/RefactorMoti/RefactorMoti/Data/Repository/AchievementRepository.swift
@@ -15,7 +15,7 @@ struct AchievementRepository: AchievementRepositoryProtocol {
                 id: $0,
                 userID: $0,
                 imageURL: URL(string: "https://picsum.photos/500"),
-                categoryID: $0,
+                category: CategoryItem(id: $0, name: "카테고리\($0)"),
                 title: "제목\($0)",
                 createdAt: Date()
             )

--- a/RefactorMoti/RefactorMoti/Data/Repository/CategoryRepository.swift
+++ b/RefactorMoti/RefactorMoti/Data/Repository/CategoryRepository.swift
@@ -9,13 +9,13 @@ import Foundation
 
 struct CategoryRepository: CategoryRepositoryProtocol {
     
-    func fetchCategories() async throws -> [String] {
+    func fetchCategories() async throws -> [CategoryItem] {
         [
-            "전체",
-            "미설정",
-            "음식",
-            "운동",
-            "개발"
+            CategoryItem(id: 0, name: "전체"),
+            CategoryItem(id: 1, name: "미설정"),
+            CategoryItem(id: 2, name: "음식"),
+            CategoryItem(id: 3, name: "운동"),
+            CategoryItem(id: 4, name: "개발")
         ]
     }
 }

--- a/RefactorMoti/RefactorMoti/Domain/Entity/Achievement.swift
+++ b/RefactorMoti/RefactorMoti/Domain/Entity/Achievement.swift
@@ -12,7 +12,7 @@ struct Achievement: Equatable {
     let id: Int
     let userID: Int
     let imageURL: URL?
-    var categoryID: Int
+    var category: CategoryItem
     var title: String
     var body: String?
     let createdAt: Date?

--- a/RefactorMoti/RefactorMoti/Domain/Entity/CategoryItem.swift
+++ b/RefactorMoti/RefactorMoti/Domain/Entity/CategoryItem.swift
@@ -11,6 +11,16 @@ struct CategoryItem: Equatable {
     
     let id: Int
     let name: String
-    var continued: Int
-    var lastChallenged: Date?
+    var continued: Int = 0
+    var lastChallenged: Date? = nil
+}
+
+
+// MARK: - Equatable
+
+extension CategoryItem {
+    
+    static func ==(lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id
+    }
 }

--- a/RefactorMoti/RefactorMoti/Domain/Entity/CategoryItem.swift
+++ b/RefactorMoti/RefactorMoti/Domain/Entity/CategoryItem.swift
@@ -1,0 +1,16 @@
+//
+//  CategoryItem.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 5/4/24.
+//
+
+import Foundation
+
+struct CategoryItem: Equatable {
+    
+    let id: Int
+    let name: String
+    var continued: Int
+    var lastChallenged: Date?
+}

--- a/RefactorMoti/RefactorMoti/Domain/RepositoryProtocol/CategoryRepositoryProtocol.swift
+++ b/RefactorMoti/RefactorMoti/Domain/RepositoryProtocol/CategoryRepositoryProtocol.swift
@@ -9,5 +9,5 @@ import Foundation
 
 protocol CategoryRepositoryProtocol {
     
-    func fetchCategories() async throws -> [String]
+    func fetchCategories() async throws -> [CategoryItem]
 }

--- a/RefactorMoti/RefactorMoti/Domain/UseCase/FetchCategoriesUseCase.swift
+++ b/RefactorMoti/RefactorMoti/Domain/UseCase/FetchCategoriesUseCase.swift
@@ -9,14 +9,14 @@ import Foundation
 
 protocol FetchCategoriesUseCaseProtocol {
     
-    func execute() async throws -> [String]
+    func execute() async throws -> [CategoryItem]
 }
 
 struct FetchCategoriesUseCase: FetchCategoriesUseCaseProtocol {
     
     // MARK: - Interface
     
-    func execute() async throws -> [String] {
+    func execute() async throws -> [CategoryItem] {
         try await repository.fetchCategories()
     }
     

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModelInputOutput.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModelInputOutput.swift
@@ -19,8 +19,8 @@ extension HomeViewModel {
         
         // MARK: Category
         
-        let categories: PassthroughSubject<[String], Never> = .init()
-        let currentCategory: PassthroughSubject<String, Never> = .init()
+        let categories: PassthroughSubject<[CategoryItem], Never> = .init()
+        let currentCategory: PassthroughSubject<CategoryItem, Never> = .init()
         
         // MARK: Achievement
         

--- a/RefactorMoti/RefactorMotiTests/Data/Repository/CategoryRepositoryTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Data/Repository/CategoryRepositoryTests.swift
@@ -6,11 +6,12 @@
 //
 
 import XCTest
+@testable import RefactorMoti
 
 final class CategoryRepositoryTests: XCTestCase {
     
-    private let defaultCategories = ["전체", "미설정"]
-    private let customCategory = "음식"
+    private let defaultCategories = [CategoryItem(id: 0, name: "전체"), CategoryItem(id: 1, name: "미설정")]
+    private let customCategory = CategoryItem(id: 2, name: "음식")
     
     func test_기본_카테고리만_있을_때_fetchCategories_수행에_성공하면_기본_category_리스트를_반환한다() async throws {
         // given

--- a/RefactorMoti/RefactorMotiTests/Domain/UseCase/FetchCategoriesUseCaseTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Domain/UseCase/FetchCategoriesUseCaseTests.swift
@@ -10,8 +10,8 @@ import XCTest
 
 final class FetchCategoriesUseCaseTests: XCTestCase {
 
-    private let defaultCategories = ["전체", "미설정"]
-    private let customCategory = "음식"
+    private let defaultCategories = [CategoryItem(id: 0, name: "전체"), CategoryItem(id: 1, name: "미설정")]
+    private let customCategory = CategoryItem(id: 2, name: "음식")
     
     func test_기본_카테고리만_있을_때_fetchCategories_수행이_성공하면_기본_리스트를_반환한다() async throws { 
         // given

--- a/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
@@ -16,7 +16,7 @@ final class HomeViewModelTests: XCTestCase {
     private let fetchCategoriesUseCase = FetchCategoriesUseCase(repository: DefaultCategoryRepositoryStub())
     private let fetchAchievementsUseCase = FetchAchievementsUseCase(repository: AchievementRepositoryStub())
     
-    private var targetCategories: [String]!
+    private var targetCategories: [CategoryItem]!
     private var targetAchievements: [Achievement]!
 
     private var viewModel: HomeViewModel!
@@ -54,10 +54,9 @@ final class HomeViewModelTests: XCTestCase {
         let expectation = XCTestExpectation()
         
         // when
-        var source: [String]?
+        var source: [CategoryItem]?
         output.categories
-            .sink { [weak self] categories in
-                guard let self else { return }
+            .sink { categories in
                 source = categories
                 expectation.fulfill()
             }
@@ -77,10 +76,9 @@ final class HomeViewModelTests: XCTestCase {
         let expectation = XCTestExpectation()
         
         // when
-        var source: String?
+        var source: CategoryItem?
         output.currentCategory
-            .sink { [weak self] currentCategory in
-                guard let self else { return }
+            .sink { currentCategory in
                 source = currentCategory
                 expectation.fulfill()
             }

--- a/RefactorMoti/RefactorMotiTests/Stub/Repository/AchievementRepositoryStub.swift
+++ b/RefactorMoti/RefactorMotiTests/Stub/Repository/AchievementRepositoryStub.swift
@@ -19,7 +19,14 @@ struct AchievementRepositoryStub: AchievementRepositoryProtocol {
     
     func fetchAchievements() async throws -> [Achievement] {
         (0..<10).map {
-            Achievement(id: $0, userID: $0, imageURL: nil, categoryID: $0, title: "", createdAt: Date())
+            Achievement(
+                id: $0,
+                userID: $0,
+                imageURL: URL(string: "https://picsum.photos/500"),
+                category: CategoryItem(id: $0, name: "카테고리\($0)"),
+                title: "제목\($0)",
+                createdAt: Date()
+            )
         }
     }
 }

--- a/RefactorMoti/RefactorMotiTests/Stub/Repository/CategoryRepositoryStub.swift
+++ b/RefactorMoti/RefactorMotiTests/Stub/Repository/CategoryRepositoryStub.swift
@@ -10,14 +10,21 @@ import Foundation
 
 struct DefaultCategoryRepositoryStub: CategoryRepositoryProtocol {
     
-    func fetchCategories() async throws -> [String] {
-        ["전체", "미설정"]
+    func fetchCategories() async throws -> [CategoryItem] {
+        [
+            CategoryItem(id: 0, name: "전체"), 
+            CategoryItem(id: 1, name: "미설정")
+        ]
     }
 }
 
 struct CustomCategoryRepositoryStub: CategoryRepositoryProtocol {
     
-    func fetchCategories() async throws -> [String] {
-        ["전체", "미설정", "음식"]
+    func fetchCategories() async throws -> [CategoryItem] {
+        [
+            CategoryItem(id: 0, name: "전체"),
+            CategoryItem(id: 1, name: "미설정"),
+            CategoryItem(id: 2, name: "음식")
+        ]
     }
 }


### PR DESCRIPTION
## Overview
CategoryItem Entity를 정의하고 적용하였습니다.
카테고리는 id로 같은지 비교해야하므로 == 연산자를 정의했습니다.

## Note
### 테스트 자동화
moti 2.0을 개발하며 처음으로 프로젝트 전역에 수정사항이 생겼습니다.
테스트를 하나하나 돌리는게 상당히 번거로운 일이라는 걸 직접 겪었고,
테스트 자동화를 만들어둔게 너무 든든했습니다.
리팩토링을 진행하며 처음 배우고 적용한 기술인데 실제 효용력(?)을 느껴 뿌듯합니다.
이후에도 새로운 도전을 과감히 할 수 있을 거 같아요 😀

### 테스트를 위한 데이터 모음
Category와 관련된 테스트에서 동일한 변수가 사용됩니다.
```swift
private let defaultCategories = [CategoryItem(id: 0, name: "전체"), CategoryItem(id: 1, name: "미설정")]
private let customCategory = CategoryItem(id: 2, name: "음식")
```
위 두 변수는 마땅한 객체 정의 방법이 떠오르지 않아 보일러 플레이트로 남게 되었습니다.
이 문제는 이후 개발 과정에서 다른 객체도 동일하게 발생할 것으로 예상됩니다.
이 때 테스트 데이터를 모아두는 enum을 정의해야 할지 고민 중입니다.

## Issue
closed #50 
