### PR TITLE
[#60] CompositionalLayout Enum 정의 + Note

### DIFF
--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -68,7 +68,8 @@
 		9BA895C02BE604DA0080D400 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895BF2BE604DA0080D400 /* HomeViewModel.swift */; };
 		9BA895C22BE604E90080D400 /* HomeViewModelInputOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895C12BE604E90080D400 /* HomeViewModelInputOutput.swift */; };
 		9BA895C92BE673120080D400 /* CategoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895C82BE673120080D400 /* CategoryItem.swift */; };
-		9BA895CB2BE714750080D400 /* SingleDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895CA2BE714750080D400 /* SingleDiffableDataSource.swift */; };
+		9BA895CF2BE725B50080D400 /* SingleDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895CD2BE725B00080D400 /* SingleDiffableDataSource.swift */; };
+		9BA895D12BE725D60080D400 /* CompositionalLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895D02BE725D60080D400 /* CompositionalLayout.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -144,7 +145,8 @@
 		9BA895BF2BE604DA0080D400 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		9BA895C12BE604E90080D400 /* HomeViewModelInputOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelInputOutput.swift; sourceTree = "<group>"; };
 		9BA895C82BE673120080D400 /* CategoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryItem.swift; sourceTree = "<group>"; };
-		9BA895CA2BE714750080D400 /* SingleDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleDiffableDataSource.swift; sourceTree = "<group>"; };
+		9BA895CD2BE725B00080D400 /* SingleDiffableDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleDiffableDataSource.swift; sourceTree = "<group>"; };
+		9BA895D02BE725D60080D400 /* CompositionalLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositionalLayout.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -170,7 +172,7 @@
 		9B289C712BDCDDB5000813C1 /* Base */ = {
 			isa = PBXGroup;
 			children = (
-				9BA895CC2BE715780080D400 /* CollectionView */,
+				9BA895CE2BE725B00080D400 /* CollectionView */,
 				9B289C722BDCDDBD000813C1 /* BaseView.swift */,
 				9B289C742BDCE249000813C1 /* BaseViewController.swift */,
 				9B289C7A2BDCF0E0000813C1 /* LayoutViewController.swift */,
@@ -500,10 +502,11 @@
 			path = Repository;
 			sourceTree = "<group>";
 		};
-		9BA895CC2BE715780080D400 /* CollectionView */ = {
+		9BA895CE2BE725B00080D400 /* CollectionView */ = {
 			isa = PBXGroup;
 			children = (
-				9BA895CA2BE714750080D400 /* SingleDiffableDataSource.swift */,
+				9BA895CD2BE725B00080D400 /* SingleDiffableDataSource.swift */,
+				9BA895D02BE725D60080D400 /* CompositionalLayout.swift */,
 			);
 			path = CollectionView;
 			sourceTree = "<group>";
@@ -650,6 +653,7 @@
 				9B289C7B2BDCF0E0000813C1 /* LayoutViewController.swift in Sources */,
 				9BA8959F2BE38D6A0080D400 /* Achievement.swift in Sources */,
 				9B411CBF2BDFD0A700A50B78 /* HomeViewController.swift in Sources */,
+				9BA895D12BE725D60080D400 /* CompositionalLayout.swift in Sources */,
 				9BA895BA2BE5FBC50080D400 /* FetchCategoriesUseCase.swift in Sources */,
 				9B289C8B2BDE4682000813C1 /* LoginView.swift in Sources */,
 				9B289C842BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift in Sources */,
@@ -671,7 +675,7 @@
 				9BA895C92BE673120080D400 /* CategoryItem.swift in Sources */,
 				9B45818C2BD936DB002A32DC /* LaunchViewModel.swift in Sources */,
 				9B289C862BDD3BA4000813C1 /* AutoLayoutWrapper+Horizontal.swift in Sources */,
-				9BA895CB2BE714750080D400 /* SingleDiffableDataSource.swift in Sources */,
+				9BA895CF2BE725B50080D400 /* SingleDiffableDataSource.swift in Sources */,
 				9B4581902BD93D3F002A32DC /* LaunchViewModelProtocol.swift in Sources */,
 				9B289C882BDD3C03000813C1 /* AutoLayoutWrapper+All.swift in Sources */,
 				9B4581802BD92FED002A32DC /* FetchVersionUseCase.swift in Sources */,

--- a/RefactorMoti/RefactorMoti/Presentation/Base/CollectionView/CompositionalLayout.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Base/CollectionView/CompositionalLayout.swift
@@ -1,0 +1,125 @@
+//
+//  CompositionalLayout.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 5/5/24.
+//
+
+import UIKit
+
+enum CompositionalLayout {
+    
+    case vertical
+    case horizontal
+    
+    func configure(
+        item: CompositionalLayoutItem,
+        group: CompositionalLayoutGroup,
+        section: CompositionalLayoutSection
+    ) -> UICollectionViewCompositionalLayout {
+        UICollectionViewCompositionalLayout { (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
+            let item = item.configure()
+            let group = group.configure(type: self, item: item)
+            return section.configure(group: group)
+        }
+    }
+}
+
+
+// MARK: - CompositionalLayoutItem
+
+struct CompositionalLayoutItem {
+    
+    let size: NSCollectionLayoutSize
+    let contentInsets: NSDirectionalEdgeInsets?
+    
+    init(
+        size: NSCollectionLayoutSize,
+        contentInsets: NSDirectionalEdgeInsets? = nil
+    ) {
+        self.size = size
+        self.contentInsets = contentInsets
+    }
+    
+    func configure() -> NSCollectionLayoutItem {
+        let item = NSCollectionLayoutItem(layoutSize: size)
+        
+        if let contentInsets {
+            item.contentInsets = contentInsets
+        }
+        
+        return item
+    }
+}
+
+
+// MARK: - CompositionalLayoutGroup
+
+struct CompositionalLayoutGroup {
+    
+    let size: NSCollectionLayoutSize
+    let count: Int
+    let contentInsets: NSDirectionalEdgeInsets?
+    let edgeSpacing: NSCollectionLayoutEdgeSpacing?
+    
+    init(
+        size: NSCollectionLayoutSize,
+        count: Int,
+        contentInsets: NSDirectionalEdgeInsets? = nil,
+        edgeSpacing: NSCollectionLayoutEdgeSpacing? = nil
+    ) {
+        self.size = size
+        self.count = count
+        self.contentInsets = contentInsets
+        self.edgeSpacing = edgeSpacing
+    }
+    
+    func configure(
+        type: CompositionalLayout,
+        item: NSCollectionLayoutItem
+    ) -> NSCollectionLayoutGroup {
+        let subitems = Array(repeating: item, count: count)
+        let group = type == .vertical
+        ? NSCollectionLayoutGroup.vertical(layoutSize: size, subitems: subitems)
+        : NSCollectionLayoutGroup.horizontal(layoutSize: size, subitems: subitems)
+        
+        if let contentInsets {
+            group.contentInsets = contentInsets
+        }
+        if let edgeSpacing {
+            group.edgeSpacing = edgeSpacing
+        }
+        
+        return group
+    }
+}
+
+
+// MARK: - CompositionalLayoutSection
+
+struct CompositionalLayoutSection {
+    
+    let orthogonalScrollingBehavior: UICollectionLayoutSectionOrthogonalScrollingBehavior
+    let header: NSCollectionLayoutBoundarySupplementaryItem?
+    let footer: NSCollectionLayoutBoundarySupplementaryItem?
+    
+    init(
+        orthogonalScrollingBehavior: UICollectionLayoutSectionOrthogonalScrollingBehavior,
+        header: NSCollectionLayoutBoundarySupplementaryItem? = nil,
+        footer: NSCollectionLayoutBoundarySupplementaryItem? = nil
+    ) {
+        self.orthogonalScrollingBehavior = orthogonalScrollingBehavior
+        self.header = header
+        self.footer = footer
+    }
+    
+    func configure(group: NSCollectionLayoutGroup) -> NSCollectionLayoutSection {
+        let section = NSCollectionLayoutSection(group: group)
+        
+        section.orthogonalScrollingBehavior = orthogonalScrollingBehavior
+        section.boundarySupplementaryItems = [header, footer].compactMap { $0 }
+        
+        return section
+    }
+}
+


### PR DESCRIPTION
## Overview
- 세로 스크롤, 가로 스크롤을 지원하는 CompositionalLayout Enum을 정의했습니다.
  - configure에서 요소들의 속성을 파라미터로 받으면 파라미터가 너무 많아지고 요소의 속성이 변경되면 메서드 자체가 변하는 문제가 있습니다. (moti 1.0처럼) 
  - 이 문제를 해결하기 위해 각 구조체를 정의하고 이를 전달 받도록 구현했습니다.

## Note
기존 moti의 CompositionalLayout 생성 코드는 많은 파라미터가 있었습니다. (Overview에 쓴 것처럼!)
이 파라미터들은 모두 CompositionalLayout 요소들(item, group, section)의 각 속성이었습니다.
이를 어떻게 하면 줄일 수 있을까 고민했고 각 요소들을 구조체로 정의하는 방법을 떠올렸습니다.
기존 코드를 보면서 어떤 부분이 어떻게 아쉬운지 느끼고 어떤 방향으로 수정할지 결정할 수 있었던 경험이었습니다.

## Issue
closed #60 
