### PR TITLE
[#65] 카테고리 추가 테스트 코드를 작성한다. + Note

### DIFF
--- a/RefactorMoti/RefactorMoti/Data/Repository/CategoryRepository.swift
+++ b/RefactorMoti/RefactorMoti/Data/Repository/CategoryRepository.swift
@@ -18,4 +18,8 @@ struct CategoryRepository: CategoryRepositoryProtocol {
             CategoryItem(id: 4, name: "개발")
         ]
     }
+    
+    func addCategory(_ category: CategoryItem) async -> Bool {
+        true
+    }
 }

--- a/RefactorMoti/RefactorMoti/Domain/RepositoryProtocol/CategoryRepositoryProtocol.swift
+++ b/RefactorMoti/RefactorMoti/Domain/RepositoryProtocol/CategoryRepositoryProtocol.swift
@@ -10,4 +10,5 @@ import Foundation
 protocol CategoryRepositoryProtocol {
     
     func fetchCategories() async throws -> [CategoryItem]
+    func addCategory(_ category: CategoryItem) async -> Bool
 }

--- a/RefactorMoti/RefactorMotiTests/Data/Repository/CategoryRepositoryTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Data/Repository/CategoryRepositoryTests.swift
@@ -13,6 +13,9 @@ final class CategoryRepositoryTests: XCTestCase {
     private let defaultCategories = [CategoryItem(id: 0, name: "전체"), CategoryItem(id: 1, name: "미설정")]
     private let customCategory = CategoryItem(id: 2, name: "음식")
     
+    
+    // MARK: - Fetch Categories
+    
     func test_기본_카테고리만_있을_때_fetchCategories_수행에_성공하면_기본_category_리스트를_반환한다() async throws {
         // given
         let repository = DefaultCategoryRepositoryStub()
@@ -38,4 +41,19 @@ final class CategoryRepositoryTests: XCTestCase {
     }
     
     func test_fetchCategories_수행에_실패하면_에러를_발생시킨다() async throws { }
+    
+
+    // MARK: - Add Category
+    
+    func test_addCategory에_성공하면_true를_반환한다() async throws {
+        // given
+        let repository = DefaultCategoryRepositoryStub()
+        let category = CategoryItem(id: 3, name: "카테고리")
+        
+        // when
+        let isSuccess = await repository.addCategory(category)
+        
+        // then
+        XCTAssertTrue(isSuccess)
+    }
 }

--- a/RefactorMoti/RefactorMotiTests/Stub/Repository/CategoryRepositoryStub.swift
+++ b/RefactorMoti/RefactorMotiTests/Stub/Repository/CategoryRepositoryStub.swift
@@ -10,21 +10,37 @@ import Foundation
 
 struct DefaultCategoryRepositoryStub: CategoryRepositoryProtocol {
     
+    private(set) var categories: [CategoryItem] = [
+        CategoryItem(id: 0, name: "전체"),
+        CategoryItem(id: 1, name: "미설정")
+    ]
+    
     func fetchCategories() async throws -> [CategoryItem] {
-        [
-            CategoryItem(id: 0, name: "전체"), 
-            CategoryItem(id: 1, name: "미설정")
-        ]
+        categories
+    }
+    
+    func addCategory(_ category: CategoryItem) async -> Bool {
+        var mutable = categories
+        mutable.append(category)
+        return true
     }
 }
 
 struct CustomCategoryRepositoryStub: CategoryRepositoryProtocol {
     
+    private(set) var categories: [CategoryItem] = [
+        CategoryItem(id: 0, name: "전체"),
+        CategoryItem(id: 1, name: "미설정"),
+        CategoryItem(id: 2, name: "음식")
+    ]
+    
     func fetchCategories() async throws -> [CategoryItem] {
-        [
-            CategoryItem(id: 0, name: "전체"),
-            CategoryItem(id: 1, name: "미설정"),
-            CategoryItem(id: 2, name: "음식")
-        ]
+        categories
+    }
+    
+    func addCategory(_ category: CategoryItem) async -> Bool {
+        var mutable = categories
+        mutable.append(category)
+        return true
     }
 }


### PR DESCRIPTION
## Overview
- 카테고리 추가 테스트 코드를 작성했습니다.
- 빌드 에러를 없애기 위해 addCategory 메서드를 정의하고 기본값인 true를 반환시켰습니다.

## Note
이번 PR에서 추가한 테스트 코드는 의미가 있는 테스트인지 고민이 깊습니다.
실제 추가 동작은 네트워크가 필요하므로 Stub에서는 true를 단순 반환하고 있기 때문입니다.
Repository 메서드에 다른 로직이 들어간다면 그 로직을 테스트한다는 의미가 있지만,
네트워크 없이 Repository를 테스트하는게 의미가 있을까 싶습니다.
개발을 진행하면서 꾸준히 고민해봐야할 점 같네요.

## Issue
closed #65 
