### PR TITLE
[#75] 카테고리 리스트 아이템을 클릭하여 현재 카테고리를 선택하는 기능을 구현한다.

### DIFF
--- a/RefactorMoti/RefactorMoti/Presentation/Home/Cell/CategoryCollectionViewCell.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/Cell/CategoryCollectionViewCell.swift
@@ -12,6 +12,12 @@ final class CategoryCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Interface
     
+    override var isSelected: Bool {
+        didSet {
+            isSelected ? selected() : deselected()
+        }
+    }
+    
     func configure(with category: CategoryItem) {
         label.text = category.name
     }
@@ -41,6 +47,14 @@ final class CategoryCollectionViewCell: UICollectionViewCell {
     }
     
     
+    // MARK: - Life Cycle
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        deselected()
+    }
+    
+    
     // MARK: - Setup
     
     private func setUpAttribute() {
@@ -48,6 +62,7 @@ final class CategoryCollectionViewCell: UICollectionViewCell {
         layer.cornerRadius = Metric.cornerRadius
         layer.borderWidth = Metric.borderWidth
         layer.borderColor = JDColor.primary.color.cgColor
+        deselected()
     }
     
     private func setUpSubview() {
@@ -58,6 +73,16 @@ final class CategoryCollectionViewCell: UICollectionViewCell {
         label.atl
             .centerY(equalTo: self.centerYAnchor)
             .horizontal(equalTo: self, constant: Metric.horizontalOffset)
+    }
+    
+    private func selected() {
+        backgroundColor = JDColor.primary.color
+        label.textColor = JDColor.background.color
+    }
+    
+    private func deselected() {
+        backgroundColor = JDColor.background.color
+        label.textColor = JDColor.primary.color
     }
 }
 

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
@@ -8,7 +8,7 @@
 import UIKit
 import JeongDesignSystem
 
-final class HomeView: BaseView { 
+final class HomeView: BaseView {
     
     // MARK: - Interface
     

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
@@ -16,6 +16,10 @@ final class HomeView: BaseView {
         addCategoryButton.publisher(for: .touchUpInside)
     }
     
+    func selectCategory(indexPath: IndexPath) {
+        categoriesCollectionView.selectItem(at: indexPath, animated: true, scrollPosition: .centeredHorizontally)
+    }
+    
     
     // MARK: - UI
     

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewController.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewController.swift
@@ -55,10 +55,11 @@ private extension HomeViewController {
             }
             .store(in: &cancellables)
         
-        output.currentCategory
-            .sink { [weak self] category in
+        output.selectedCategoryIndex
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] indexPath in
                 guard let self else { return }
-                print("category: \(category)") // swiftlint:disable:this all
+                layoutView.selectCategory(indexPath: indexPath)
             }
             .store(in: &cancellables)
         

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewController.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewController.swift
@@ -55,6 +55,13 @@ private extension HomeViewController {
             }
             .store(in: &cancellables)
         
+        output.currentCategory
+            .sink { [weak self] category in
+                guard let self else { return }
+                print("category: \(category)") // swiftlint:disable:this all
+            }
+            .store(in: &cancellables)
+        
         output.achievements
             .sink { [weak self] achievements in
                 guard let self else { return }
@@ -119,6 +126,12 @@ private extension HomeViewController {
 extension HomeViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        print("selected: \(indexPath.row)") // swiftlint:disable:this all
+        if collectionView == layoutView.categoriesCollectionView {
+            didSelectCategoryCollectionView(indexPath: indexPath)
+        }
+    }
+    
+    private func didSelectCategoryCollectionView(indexPath: IndexPath) {
+        input.selectCategoryCell.send(indexPath)
     }
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
@@ -108,7 +108,7 @@ private extension HomeViewModel {
     }
     
     func selectCategory(at indexPath: IndexPath) {
-        guard categories.count < indexPath.row else {
+        guard indexPath.row < categories.count else {
             return
         }
         

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
@@ -44,6 +44,7 @@ final class HomeViewModel {
         output.categories.value
     }
     
+    
     // MARK: - Initializer
     
     init(
@@ -108,7 +109,7 @@ private extension HomeViewModel {
     }
     
     func selectCategory(at indexPath: IndexPath) {
-        guard indexPath.row < categories.count else {
+        guard indexPath.item < categories.count else {
             return
         }
         
@@ -133,7 +134,7 @@ private extension HomeViewModel {
     func fetchCategories() {
         Task {
             guard let categories = try? await fetchCategoriesUseCase.execute(),
-                  let firstCategory = categories.first else {
+                !categories.isEmpty else {
                 // TODO: 에러 발생
                 return
             }
@@ -141,9 +142,7 @@ private extension HomeViewModel {
             output.categories.send(categories)
             categoryDataSource?.update(data: categories)
 
-            if !categories.isEmpty {
-                output.selectedCategoryIndex.send(IndexPath(row: 0, section: 0))
-            }
+            selectCategory(at: IndexPath(item: 0, section: 0))
         }
     }
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
@@ -112,8 +112,7 @@ private extension HomeViewModel {
             return
         }
         
-        let selectedCategory = categories[indexPath.row]
-        output.currentCategory.send(selectedCategory)
+        output.selectedCategoryIndex.send(indexPath)
     }
 }
 
@@ -140,9 +139,11 @@ private extension HomeViewModel {
             }
             
             output.categories.send(categories)
-            output.currentCategory.send(firstCategory)
-            
             categoryDataSource?.update(data: categories)
+
+            if !categories.isEmpty {
+                output.selectedCategoryIndex.send(IndexPath(row: 0, section: 0))
+            }
         }
     }
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModelInputOutput.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModelInputOutput.swift
@@ -22,7 +22,7 @@ extension HomeViewModel {
         // MARK: Category
         
         let categories: CurrentValueSubject<[CategoryItem], Never> = .init([])
-        let currentCategory: PassthroughSubject<CategoryItem, Never> = .init()
+        let selectedCategoryIndex: PassthroughSubject<IndexPath, Never> = .init()
         let isAddedCategorySuccess: PassthroughSubject<Bool, Never> = .init()
         
         // MARK: Achievement

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModelInputOutput.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModelInputOutput.swift
@@ -14,6 +14,7 @@ extension HomeViewModel {
         
         let viewDidLoad: PassthroughSubject<Void, Never> = .init()
         let addCategory: PassthroughSubject<CategoryItem, Never> = .init()
+        let selectCategoryCell: PassthroughSubject<IndexPath, Never> = .init()
     }
     
     struct Output {

--- a/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
@@ -142,23 +142,32 @@ final class HomeViewModelTests: XCTestCase {
     
     func test_selectCategory가_input될_때_유효한_index면_currentCategory_output은_선택한_카테고리() throws {
         // given
-        let expectation = XCTestExpectation()
-        let target = targetCategories[0]
+        let expectation1 = XCTestExpectation()
+        let expectation2 = XCTestExpectation()
+        let targetIndex = 1
+        let target = targetCategories[targetIndex]
         
         // when
         var source: CategoryItem?
+        output.categories
+            .sink { _ in
+                expectation1.fulfill()
+            }
+            .store(in: &cancellables)
+        
         output.currentCategory
             .sink { currentCategory in
                 source = currentCategory
-                expectation.fulfill()
+                expectation2.fulfill()
             }
             .store(in: &cancellables)
         
         input.viewDidLoad.send()
-        input.selectCategoryCell.send(IndexPath(row: 0, section: 0))
+        wait(for: [expectation1], timeout: 5)
+        input.selectCategoryCell.send(IndexPath(row: targetIndex, section: 0))
         
         // then
-        wait(for: [expectation], timeout: 5)
+        wait(for: [expectation2], timeout: 5)
         
         XCTAssertNotNil(source)
         XCTAssertEqual(source, target)

--- a/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
@@ -140,6 +140,30 @@ final class HomeViewModelTests: XCTestCase {
     
     func test_deleteCategory가_input될_때_카테고리_삭제에_실패하면_output은_false() throws { }
     
+    func test_selectCategory가_input될_때_유효한_index면_currentCategory_output은_선택한_카테고리() throws {
+        // given
+        let expectation = XCTestExpectation()
+        let target = targetCategories[0]
+        
+        // when
+        var source: CategoryItem?
+        output.currentCategory
+            .sink { currentCategory in
+                source = currentCategory
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        input.viewDidLoad.send()
+        input.selectCategoryCell.send(IndexPath(row: 0, section: 0))
+        
+        // then
+        wait(for: [expectation], timeout: 5)
+        
+        XCTAssertNotNil(source)
+        XCTAssertEqual(source, target)
+    }
+    
     
     // MARK: - Achievement
     

--- a/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
@@ -71,15 +71,15 @@ final class HomeViewModelTests: XCTestCase {
         XCTAssertEqual(source, targetCategories)
     }
     
-    func test_viewDidLoad가_input되면_현재_카테고리에_첫_번째_카테고리를_output() throws {
+    func test_viewDidLoad가_input되면_첫_번째_카테고리를_output() throws {
         // given
         let expectation = XCTestExpectation()
         
         // when
-        var source: CategoryItem?
-        output.currentCategory
-            .sink { currentCategory in
-                source = currentCategory
+        var source: IndexPath?
+        output.selectedCategoryIndex
+            .sink { indexPath in
+                source = indexPath
                 expectation.fulfill()
             }
             .store(in: &cancellables)
@@ -90,7 +90,7 @@ final class HomeViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: 5)
         
         XCTAssertNotNil(source)
-        XCTAssertEqual(source, targetCategories.first)
+        XCTAssertEqual(source, IndexPath(row: 0, section: 0))
     }
     
     func test_addCategory가_input될_때_카테고리_추가에_성공하면_output은_새로운_카테고리_리스트() throws {
@@ -145,32 +145,33 @@ final class HomeViewModelTests: XCTestCase {
         let expectation1 = XCTestExpectation()
         let expectation2 = XCTestExpectation()
         let targetIndex = 1
+        let targetIndexPath = IndexPath(row: targetIndex, section: 0)
         let target = targetCategories[targetIndex]
         
         // when
-        var source: CategoryItem?
+        var source: IndexPath?
         output.categories
             .sink { _ in
                 expectation1.fulfill()
             }
             .store(in: &cancellables)
         
-        output.currentCategory
-            .sink { currentCategory in
-                source = currentCategory
+        output.selectedCategoryIndex
+            .sink { indexPath in
+                source = indexPath
                 expectation2.fulfill()
             }
             .store(in: &cancellables)
         
         input.viewDidLoad.send()
         wait(for: [expectation1], timeout: 5)
-        input.selectCategoryCell.send(IndexPath(row: targetIndex, section: 0))
+        input.selectCategoryCell.send(targetIndexPath)
         
         // then
         wait(for: [expectation2], timeout: 5)
         
         XCTAssertNotNil(source)
-        XCTAssertEqual(source, target)
+        XCTAssertEqual(source, targetIndexPath)
     }
     
     


### PR DESCRIPTION
## Overview
- 이슈 번호를 착각하여 #75를 #70으로 커밋하였습니다 ;;
- 카테고리 리스트 아이템을 클릭하여 현재 카테고리를 선택하는 기능을 구현하였습니다.
  - ViewModel에서 selectedCategoryIndex output을 send하면 CollectionView에 select 처리합니다.

## Note
### 테스트 코드
이 과정에서 테스트 코드의 신뢰도에 대해 고민하였습니다.
테스트 코드 자체를 잘못 작성하여 로직의 버그를 찾지 못하였습니다.
fetchCategories 메서드에서 첫 번째 카테고리를 미리 선택한다는 것을 잊고 잘못된 테스트 조건을 세웠기 때문입니다.
여기서 배운 점은,
1. 메서드는 딱 한 가지 역할만 가지는게 가장 좋다.
2. 테스트 코드를 100% 신뢰해서는 안 된다.
입니다.

1번은 경험상 애매한 상황도 많았는데 어떻게 해결할 수 있을지 계속 고민해야겠습니다.
2번은 테스트 경험이 쌓이면 더 안전한 테스트 통과 조건을 세우도록 노력할 것입니다.

### PR 범위
이번 PR은 범위를 크게 잡아보았습니다.
하나의 작업을 단위로 PR 범위를 잡았습니다.
기존에는 테스트, ViewModel, View를 각각 1개의 PR로 작성했다면,
이번에는 이 세 가지를 하나의 작업으로 묶어 PR로 작성했습니다.
개인적으로 PR이 커지니 어떤 작업을 했는지 보려면 커밋을 순서대로 봐야한다는 점이 불편하다고 느껴졌습니다.
또한 이렇게 Note가 분리가 되어 작업의 분리가 명확하지 않은 거 같아요.
뿐만 아니라 커밋을 작성할 때도 안일하고 크게크게 커밋하는 거 같습니다.
적정한 PR의 범위가 무엇일지 다시 고민해봐야겠어요.

## Screenshot
<img src = "https://github.com/jeongju9216/moti-2.0/assets/89075274/c1ac2aba-1efc-44b0-b0ba-2293fed049dc" width = "40%">
<img src = https://github.com/jeongju9216/moti-2.0/assets/89075274/98dd14f4-5b96-40cf-82cb-3a90c423897f"" width = "40%">

## Issue
closed #75 
