### PR TITLE
[#85] 카테고리 추가 버튼을 정사각형 모양으로 설정

### DIFF
--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
@@ -59,6 +59,7 @@ final class HomeView: BaseView {
     
     override func setUpConstraint() {
         addCategoryButton.atl
+            .width(equalTo: addCategoryButton.heightAnchor)
             .height(Metric.CategoryList.height)
             .top(equalTo: safeAreaLayoutGuide.topAnchor, constant: Metric.CategoryList.topOffset)
             .left(equalTo: safeAreaLayoutGuide.leftAnchor, constant: Metric.AddCategoryButton.horizontalOffset)


### PR DESCRIPTION
## Overview
카테고리 추가 버튼을 정사각형 모양으로 설정하였습니다.

## Screenshot
<img src = "https://github.com/jeongju9216/moti-2.0/assets/89075274/9c3e0d6b-9a57-4723-b761-8bf6f2aed379" width = "40%">

## Issue
closed #85 