### PR TITLE
[#80] Firebase로 Apple Login을 연동한다.

### DIFF
--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		9B4581902BD93D3F002A32DC /* LaunchViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B45818F2BD93D3F002A32DC /* LaunchViewModelProtocol.swift */; };
 		9B95D91B2BEF0E12003BFDC3 /* AppleLoginRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D91A2BEF0E12003BFDC3 /* AppleLoginRequester.swift */; };
 		9B95D91D2BEF146A003BFDC3 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 9B95D91C2BEF146A003BFDC3 /* FirebaseAuth */; };
+		9B95D91F2BEF37FF003BFDC3 /* AppleLoginError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D91E2BEF37FF003BFDC3 /* AppleLoginError.swift */; };
 		9BA895872BDFDB5B0080D400 /* JeongDesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 9BA895862BDFDB5B0080D400 /* JeongDesignSystem */; };
 		9BA8958C2BE11C820080D400 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA8958B2BE11C820080D400 /* HomeViewModelTests.swift */; };
 		9BA895992BE387870080D400 /* AchievementRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895982BE387870080D400 /* AchievementRepositoryTests.swift */; };
@@ -139,6 +140,7 @@
 		9B45818F2BD93D3F002A32DC /* LaunchViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewModelProtocol.swift; sourceTree = "<group>"; };
 		9B95D9182BEF0D12003BFDC3 /* RefactorMoti.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RefactorMoti.entitlements; sourceTree = "<group>"; };
 		9B95D91A2BEF0E12003BFDC3 /* AppleLoginRequester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginRequester.swift; sourceTree = "<group>"; };
+		9B95D91E2BEF37FF003BFDC3 /* AppleLoginError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginError.swift; sourceTree = "<group>"; };
 		9BA8958B2BE11C820080D400 /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
 		9BA895982BE387870080D400 /* AchievementRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepositoryTests.swift; sourceTree = "<group>"; };
 		9BA8959A2BE38CCA0080D400 /* AchievementRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepository.swift; sourceTree = "<group>"; };
@@ -424,6 +426,7 @@
 			isa = PBXGroup;
 			children = (
 				9B95D91A2BEF0E12003BFDC3 /* AppleLoginRequester.swift */,
+				9B95D91E2BEF37FF003BFDC3 /* AppleLoginError.swift */,
 			);
 			path = AppleLogin;
 			sourceTree = "<group>";
@@ -710,6 +713,7 @@
 				9BA895D42BE74F880080D400 /* CategoryCollectionViewCell.swift in Sources */,
 				9BA895D12BE725D60080D400 /* CompositionalLayout.swift in Sources */,
 				9BA895BA2BE5FBC50080D400 /* FetchCategoriesUseCase.swift in Sources */,
+				9B95D91F2BEF37FF003BFDC3 /* AppleLoginError.swift in Sources */,
 				9B289C8B2BDE4682000813C1 /* LoginView.swift in Sources */,
 				9B289C842BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift in Sources */,
 				9B95D91B2BEF0E12003BFDC3 /* AppleLoginRequester.swift in Sources */,

--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		9B45818C2BD936DB002A32DC /* LaunchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B45818B2BD936DB002A32DC /* LaunchViewModel.swift */; };
 		9B45818E2BD93A02002A32DC /* FetchVersionUseCaseStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B45818D2BD93A02002A32DC /* FetchVersionUseCaseStub.swift */; };
 		9B4581902BD93D3F002A32DC /* LaunchViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B45818F2BD93D3F002A32DC /* LaunchViewModelProtocol.swift */; };
+		9B95D91B2BEF0E12003BFDC3 /* AppleLoginRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D91A2BEF0E12003BFDC3 /* AppleLoginRequester.swift */; };
+		9B95D91D2BEF146A003BFDC3 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 9B95D91C2BEF146A003BFDC3 /* FirebaseAuth */; };
 		9BA895872BDFDB5B0080D400 /* JeongDesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 9BA895862BDFDB5B0080D400 /* JeongDesignSystem */; };
 		9BA8958C2BE11C820080D400 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA8958B2BE11C820080D400 /* HomeViewModelTests.swift */; };
 		9BA895992BE387870080D400 /* AchievementRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895982BE387870080D400 /* AchievementRepositoryTests.swift */; };
@@ -135,6 +137,8 @@
 		9B45818B2BD936DB002A32DC /* LaunchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewModel.swift; sourceTree = "<group>"; };
 		9B45818D2BD93A02002A32DC /* FetchVersionUseCaseStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchVersionUseCaseStub.swift; sourceTree = "<group>"; };
 		9B45818F2BD93D3F002A32DC /* LaunchViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewModelProtocol.swift; sourceTree = "<group>"; };
+		9B95D9182BEF0D12003BFDC3 /* RefactorMoti.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RefactorMoti.entitlements; sourceTree = "<group>"; };
+		9B95D91A2BEF0E12003BFDC3 /* AppleLoginRequester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginRequester.swift; sourceTree = "<group>"; };
 		9BA8958B2BE11C820080D400 /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
 		9BA895982BE387870080D400 /* AchievementRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepositoryTests.swift; sourceTree = "<group>"; };
 		9BA8959A2BE38CCA0080D400 /* AchievementRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepository.swift; sourceTree = "<group>"; };
@@ -170,6 +174,7 @@
 				9B4581742BD7EC40002A32DC /* FirebaseDatabase in Frameworks */,
 				9BA895872BDFDB5B0080D400 /* JeongDesignSystem in Frameworks */,
 				9BA895DC2BE7AF820080D400 /* Jeongfisher in Frameworks */,
+				9B95D91D2BEF146A003BFDC3 /* FirebaseAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -211,6 +216,7 @@
 		9B289C892BDE466B000813C1 /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				9B95D9192BEF0E0B003BFDC3 /* AppleLogin */,
 				9B289C8A2BDE4682000813C1 /* LoginView.swift */,
 				9B289C8C2BDE4687000813C1 /* LoginViewController.swift */,
 				9B411CB02BDFC31D00A50B78 /* LoginViewModelProtocol.swift */,
@@ -262,6 +268,7 @@
 		9B4581202BD52EB7002A32DC /* RefactorMoti */ = {
 			isa = PBXGroup;
 			children = (
+				9B95D9182BEF0D12003BFDC3 /* RefactorMoti.entitlements */,
 				9B4581602BD7EA34002A32DC /* Application */,
 				9B45815F2BD7EA26002A32DC /* Presentation */,
 				9B45815D2BD7EA1E002A32DC /* Domain */,
@@ -411,6 +418,14 @@
 				9B289C782BDCED2C000813C1 /* LaunchView.swift */,
 			);
 			path = Launch;
+			sourceTree = "<group>";
+		};
+		9B95D9192BEF0E0B003BFDC3 /* AppleLogin */ = {
+			isa = PBXGroup;
+			children = (
+				9B95D91A2BEF0E12003BFDC3 /* AppleLoginRequester.swift */,
+			);
+			path = AppleLogin;
 			sourceTree = "<group>";
 		};
 		9BA8958D2BE3835C0080D400 /* Domain */ = {
@@ -568,6 +583,7 @@
 				9B4581732BD7EC40002A32DC /* FirebaseDatabase */,
 				9BA895862BDFDB5B0080D400 /* JeongDesignSystem */,
 				9BA895DB2BE7AF820080D400 /* Jeongfisher */,
+				9B95D91C2BEF146A003BFDC3 /* FirebaseAuth */,
 			);
 			productName = RefactorMoti;
 			productReference = 9B45811E2BD52EB7002A32DC /* RefactorMoti.app */;
@@ -696,6 +712,7 @@
 				9BA895BA2BE5FBC50080D400 /* FetchCategoriesUseCase.swift in Sources */,
 				9B289C8B2BDE4682000813C1 /* LoginView.swift in Sources */,
 				9B289C842BDD3B9F000813C1 /* AutoLayoutWrapper+Vertical.swift in Sources */,
+				9B95D91B2BEF0E12003BFDC3 /* AppleLoginRequester.swift in Sources */,
 				9B289C792BDCED2C000813C1 /* LaunchView.swift in Sources */,
 				9B45816C2BD7EAED002A32DC /* VersionRepository.swift in Sources */,
 				9B411CB32BDFC31F00A50B78 /* LoginViewModel.swift in Sources */,
@@ -902,6 +919,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = RefactorMoti/RefactorMoti.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -932,6 +950,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = RefactorMoti/RefactorMoti.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1068,6 +1087,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9B4581722BD7EC40002A32DC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseDatabase;
+		};
+		9B95D91C2BEF146A003BFDC3 /* FirebaseAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9B4581722BD7EC40002A32DC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAuth;
 		};
 		9BA895862BDFDB5B0080D400 /* JeongDesignSystem */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/RefactorMoti/RefactorMoti/Presentation/Login/AppleLogin/AppleLoginError.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Login/AppleLogin/AppleLoginError.swift
@@ -1,0 +1,16 @@
+//
+//  AppleLoginError.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 5/11/24.
+//
+
+import Foundation
+
+enum AppleLoginError: Error {
+    
+    case invalidCredential
+    case invalidNonce
+    case invalidIdentityToken
+    case invalidUserID
+}

--- a/RefactorMoti/RefactorMoti/Presentation/Login/AppleLogin/AppleLoginRequester.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Login/AppleLogin/AppleLoginRequester.swift
@@ -21,6 +21,7 @@ enum LoginError: Error {
     case invalidCredential
     case invalidNonce
     case invalidIdentityToken
+    case invalidUserID
 }
 
 final class AppleLoginRequester: NSObject {
@@ -108,8 +109,12 @@ extension AppleLoginRequester: ASAuthorizationControllerDelegate {
                 delegate?.appleLoginRequester(self, didLoginFailed: error!)
                 return
             }
+            guard let userUID = authResult?.user.uid else {
+                delegate?.appleLoginRequester(self, didLoginFailed: LoginError.invalidUserID)
+                return
+            }
             
-            delegate?.appleLoginRequester(self, didLoginSuccess: authResult?.user.uid)
+            delegate?.appleLoginRequester(self, didLoginSuccess: userUID)
         }
     }
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Login/AppleLogin/AppleLoginRequester.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Login/AppleLogin/AppleLoginRequester.swift
@@ -1,0 +1,164 @@
+//
+//  AppleLoginRequester.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 5/11/24.
+//
+
+import Foundation
+import AuthenticationServices
+import CryptoKit
+import FirebaseAuth
+
+protocol AppleLoginRequesterDelegate: AnyObject {
+
+    func appleLoginRequester(_ loginRequester: AppleLoginRequester, didLoginSuccess token: String)
+    func appleLoginRequester(_ loginRequester: AppleLoginRequester, didLoginFailed error: Error)
+}
+
+enum LoginError: Error {
+    
+    case invalidCredential
+    case invalidNonce
+    case invalidIdentityToken
+}
+
+final class AppleLoginRequester: NSObject {
+    
+    // MARK: - Interface
+
+    weak var delegate: AppleLoginRequesterDelegate?
+    
+    func request() {
+        let nonce = randomNonceString()
+        currentNonce = nonce
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = sha256(nonce)
+        
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.presentationContextProvider = self
+        controller.performRequests()
+    }
+    
+    
+    // MARK: - Attribute
+
+    private var window: UIWindow
+    private var currentNonce: String?
+    
+    
+    // MARK: - Initializer
+    
+    init(window: UIWindow) {
+        self.window = window
+    }
+}
+
+
+// MARK: - ASAuthorizationControllerDelegate
+
+extension AppleLoginRequester: ASAuthorizationControllerDelegate {
+
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            delegate?.appleLoginRequester(self, didLoginFailed: LoginError.invalidCredential)
+            return
+        }
+        
+        guard let nonce = currentNonce else {
+            delegate?.appleLoginRequester(self, didLoginFailed: LoginError.invalidNonce)
+            return
+        }
+        
+        guard let identityTokenData = appleIDCredential.identityToken,
+              let identityToken = String(data: identityTokenData, encoding: .utf8)
+        else {
+            delegate?.appleLoginRequester(self, didLoginFailed: LoginError.invalidIdentityToken)
+            return
+        }
+        
+        firebaseLogin(identityToken: identityToken, nonce: nonce, credential: appleIDCredential)
+    }
+    
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: Error
+    ) {
+        delegate?.appleLoginRequester(self, didLoginFailed: error)
+    }
+    
+    private func firebaseLogin(identityToken: String, nonce: String, credential: ASAuthorizationAppleIDCredential) {
+        // Initialize a Firebase credential, including the user's full name.
+        let credential = OAuthProvider.appleCredential(
+            withIDToken: identityToken,
+            rawNonce: nonce,
+            fullName: credential.fullName
+        )
+        
+        // Sign in with Firebase.
+        Auth.auth().signIn(with: credential) { [weak self] authResult, error in
+            guard let self else { return }
+            guard error == nil else {
+                delegate?.appleLoginRequester(self, didLoginFailed: error!)
+                return
+            }
+            
+            delegate?.appleLoginRequester(self, didLoginSuccess: authResult?.user.uid)
+        }
+    }
+}
+
+
+// MARK: - ASAuthorizationControllerPresentationContextProviding
+
+extension AppleLoginRequester: ASAuthorizationControllerPresentationContextProviding {
+
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        window
+    }
+}
+
+
+// MARK: - Nonce
+
+private extension AppleLoginRequester {
+    
+    func randomNonceString(length: Int = 32) -> String {
+        guard length > 0 else {
+            return ""
+        }
+        
+        var randomBytes: [UInt8] = Array(repeating: 0, count: length)
+        let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+        if errorCode != errSecSuccess {
+            fatalError(
+                "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
+            )
+        }
+        
+        let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        let nonce = randomBytes.map { byte in
+            // Pick a random character from the set, wrapping around if needed.
+            charset[Int(byte) % charset.count]
+        }
+        
+        return String(nonce)
+    }
+    
+    func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            String(format: "%02x", $0)
+        }.joined()
+        
+        return hashString
+    }
+}
+

--- a/RefactorMoti/RefactorMoti/Presentation/Login/LoginViewController.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Login/LoginViewController.swift
@@ -82,7 +82,7 @@ private extension LoginViewController {
 
 // MARK: - AppleLoginRequesterDelegate
 
-extension LoginViewController: AppleLoginRequesterDelegate {
+extension LoginViewController: AppleLoginRequester.Delegate {
     
     func appleLoginRequester(_ loginRequester: AppleLoginRequester, didLoginSuccess token: String) {
         input.login.send()

--- a/RefactorMoti/RefactorMoti/Presentation/Login/LoginViewController.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Login/LoginViewController.swift
@@ -7,18 +7,34 @@
 
 import UIKit
 import Combine
+import CryptoKit
+import AuthenticationServices
 
 final class LoginViewController: LayoutViewController<LoginView> {
     
     // MARK: - Attribute
+    
+    // MARK: ViewModel
     
     private let viewModel = LoginViewModel()
     private let input = LoginViewModel.Input()
     private var output: LoginViewModel.Output { viewModel.output }
     private var cancellables: Set<AnyCancellable> = []
     
+    // MARK: Apple Login
     
-    // MARK: - Binding
+    private lazy var appleLoginRequester: AppleLoginRequester? = {
+        guard let window = view.window else {
+            return nil
+        }
+        
+        let appleLoginRequester = AppleLoginRequester(window: window)
+        appleLoginRequester.delegate = self
+        return appleLoginRequester
+    }()
+    
+    
+    // MARK: - Setup
     
     override func setUpBinding() {
         viewModel.bind(input: input)
@@ -30,7 +46,7 @@ final class LoginViewController: LayoutViewController<LoginView> {
         layoutView.loginButtonDidTap
             .sink { [weak self] in
                 guard let self else { return }
-                input.login.send()
+                appleLoginRequester?.request()
             }
             .store(in: &cancellables)
     }
@@ -62,3 +78,18 @@ private extension LoginViewController {
         present(navigationVC, animated: true)
     }
 }
+
+
+// MARK: - AppleLoginRequesterDelegate
+
+extension LoginViewController: AppleLoginRequesterDelegate {
+    
+    func appleLoginRequester(_ loginRequester: AppleLoginRequester, didLoginSuccess token: String) {
+        input.login.send()
+    }
+    
+    func appleLoginRequester(_ loginRequester: AppleLoginRequester, didLoginFailed error: any Error) {
+        // TODO: Alert 표시
+    }
+}
+

--- a/RefactorMoti/RefactorMoti/RefactorMoti.entitlements
+++ b/RefactorMoti/RefactorMoti/RefactorMoti.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Overview
- 애플 로그인 버튼을 추가하였습니다.
- 애플 로그인에 성공하면 파이어베이스에 유저를 등록합니다.
- 로그인에 성공하면 홈 화면으로 이동합니다.
  - 자동 로그인은 별도의 티켓으로 작업합니다.

## Screenshot

https://github.com/jeongju9216/moti-2.0/assets/89075274/66ee5deb-304c-4888-a233-ff5584eee589


## Issue
closed #80 
