### PR TITLE
[#83] Firebase에서 카테고리 리스트를 가져오도록 수정 / 카테고리에 createAt 추가 및 정렬

### DIFF
--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		9B95D91F2BEF37FF003BFDC3 /* AppleLoginError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D91E2BEF37FF003BFDC3 /* AppleLoginError.swift */; };
 		9B95D9232BEF44AA003BFDC3 /* CreateDefaultCategoriesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D9222BEF44AA003BFDC3 /* CreateDefaultCategoriesUseCase.swift */; };
 		9B95D9252BEF5A8B003BFDC3 /* CreateDefaultCategoriesUseCaseStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D9242BEF5A8B003BFDC3 /* CreateDefaultCategoriesUseCaseStub.swift */; };
+		9B95D9272BEFBB7F003BFDC3 /* FirebaseStorageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D9262BEFBB7F003BFDC3 /* FirebaseStorageError.swift */; };
 		9BA895872BDFDB5B0080D400 /* JeongDesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 9BA895862BDFDB5B0080D400 /* JeongDesignSystem */; };
 		9BA8958C2BE11C820080D400 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA8958B2BE11C820080D400 /* HomeViewModelTests.swift */; };
 		9BA895992BE387870080D400 /* AchievementRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895982BE387870080D400 /* AchievementRepositoryTests.swift */; };
@@ -143,6 +144,7 @@
 		9B95D91E2BEF37FF003BFDC3 /* AppleLoginError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginError.swift; sourceTree = "<group>"; };
 		9B95D9222BEF44AA003BFDC3 /* CreateDefaultCategoriesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDefaultCategoriesUseCase.swift; sourceTree = "<group>"; };
 		9B95D9242BEF5A8B003BFDC3 /* CreateDefaultCategoriesUseCaseStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDefaultCategoriesUseCaseStub.swift; sourceTree = "<group>"; };
+		9B95D9262BEFBB7F003BFDC3 /* FirebaseStorageError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseStorageError.swift; sourceTree = "<group>"; };
 		9BA8958B2BE11C820080D400 /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
 		9BA895982BE387870080D400 /* AchievementRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepositoryTests.swift; sourceTree = "<group>"; };
 		9BA8959A2BE38CCA0080D400 /* AchievementRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepository.swift; sourceTree = "<group>"; };
@@ -380,6 +382,7 @@
 			isa = PBXGroup;
 			children = (
 				9B45816F2BD7EB37002A32DC /* FirebaseStorage.swift */,
+				9B95D9262BEFBB7F003BFDC3 /* FirebaseStorageError.swift */,
 			);
 			path = Firebase;
 			sourceTree = "<group>";
@@ -738,6 +741,7 @@
 				9B289C822BDD3B6C000813C1 /* AutoLayoutWrapper+Center.swift in Sources */,
 				9BA895C92BE673120080D400 /* CategoryItem.swift in Sources */,
 				9B45818C2BD936DB002A32DC /* LaunchViewModel.swift in Sources */,
+				9B95D9272BEFBB7F003BFDC3 /* FirebaseStorageError.swift in Sources */,
 				9BA895DE2BE7B0460080D400 /* AchievementCollectionViewCell.swift in Sources */,
 				9B289C862BDD3BA4000813C1 /* AutoLayoutWrapper+Horizontal.swift in Sources */,
 				9BA895CF2BE725B50080D400 /* SingleDiffableDataSource.swift in Sources */,

--- a/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
+++ b/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
@@ -47,10 +47,18 @@ final class FirebaseStorage: FirebaseStorageProtocol {
             return true
         }
         
+        guard let categoryRef = userRef?.child(Path.category) else {
+            return false
+        }
+        
         do {
             for category in Constant.defaultCategories {
-                let dict = CategoryItem(name: category).toInformation()
-                try await userRef?.child(Path.category).child(category).setValue(dict)
+                guard let autoID = categoryRef.childByAutoId().key else {
+                    continue
+                }
+                
+                let information = CategoryItem(id: autoID, name: category).toInformation()
+                try await categoryRef.child(autoID).setValue(information)
             }
         } catch {
             return false

--- a/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorageError.swift
+++ b/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorageError.swift
@@ -1,0 +1,13 @@
+//
+//  FirebaseStorageError.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 5/11/24.
+//
+
+import Foundation
+
+enum FirebaseStorageError: Error {
+    
+    case nonexistUserReference
+}

--- a/RefactorMoti/RefactorMoti/Data/Repository/AchievementRepository.swift
+++ b/RefactorMoti/RefactorMoti/Data/Repository/AchievementRepository.swift
@@ -15,7 +15,7 @@ struct AchievementRepository: AchievementRepositoryProtocol {
                 id: $0,
                 userID: $0,
                 imageURL: URL(string: "https://picsum.photos/500"),
-                category: CategoryItem(id: $0, name: "카테고리\($0)"),
+                category: CategoryItem(id: "\($0)", name: "카테고리\($0)"),
                 title: "제목\($0)",
                 createdAt: Date()
             )

--- a/RefactorMoti/RefactorMoti/Data/Repository/CategoryRepository.swift
+++ b/RefactorMoti/RefactorMoti/Data/Repository/CategoryRepository.swift
@@ -10,13 +10,7 @@ import Foundation
 struct CategoryRepository: CategoryRepositoryProtocol {
     
     func fetchCategories() async throws -> [CategoryItem] {
-        [
-            CategoryItem(id: 0, name: "전체"),
-            CategoryItem(id: 1, name: "미설정"),
-            CategoryItem(id: 2, name: "맛있는 음식"),
-            CategoryItem(id: 3, name: "힘든 운동"),
-            CategoryItem(id: 4, name: "재밌는 개발")
-        ]
+        try await firebaseStorage.fetchCategories()
     }
     
     func addCategory(_ category: CategoryItem) async -> Bool {

--- a/RefactorMoti/RefactorMoti/Domain/Entity/CategoryItem.swift
+++ b/RefactorMoti/RefactorMoti/Domain/Entity/CategoryItem.swift
@@ -40,7 +40,7 @@ extension CategoryItem {
             Key.id: id,
             Key.name: name,
             Key.continued: continued,
-            Key.createdAt: Date()
+            Key.createdAt: Date().timeIntervalSince1970
         ]
         if let lastChallenged {
             information[Key.lastChallenged] = lastChallenged

--- a/RefactorMoti/RefactorMoti/Domain/Entity/CategoryItem.swift
+++ b/RefactorMoti/RefactorMoti/Domain/Entity/CategoryItem.swift
@@ -32,16 +32,16 @@ struct CategoryItem: Hashable {
 
 extension CategoryItem {
     
-    func toDictionary() -> [String: Any] {
-        var dict: [String: Any] = [
-            "id": id,
-            "name": name,
-            "continued": continued
+    func toInformation() -> [String: Any] {
+        var information: [String: Any] = [
+            Key.id: id,
+            Key.name: name,
+            Key.continued: continued
         ]
         if let lastChallenged {
-            dict["lastChallenged"] = lastChallenged
+            information[Key.lastChallenged] = lastChallenged
         }
-        return dict
+        return information
     }
 }
 
@@ -54,3 +54,18 @@ extension CategoryItem {
         lhs.id == rhs.id
     }
 }
+
+
+// MARK: - Constant
+
+private extension CategoryItem {
+    
+    enum Key {
+        
+        static let id = "id"
+        static let name = "name"
+        static let continued = "continued"
+        static let lastChallenged = "lastChallenged"
+    }
+}
+

--- a/RefactorMoti/RefactorMoti/Domain/Entity/CategoryItem.swift
+++ b/RefactorMoti/RefactorMoti/Domain/Entity/CategoryItem.swift
@@ -9,22 +9,10 @@ import Foundation
 
 struct CategoryItem: Hashable {
     
-    let id: Int
+    let id: String
     let name: String
     var continued: Int = 0
     var lastChallenged: Date? = nil
-    
-    init(
-        id: Int = UUID().hashValue,
-        name: String,
-        continued: Int = 0,
-        lastChallenged: Date? = nil
-    ) {
-        self.id = id
-        self.name = name
-        self.continued = continued
-        self.lastChallenged = lastChallenged
-    }
 }
 
 
@@ -33,7 +21,7 @@ struct CategoryItem: Hashable {
 extension CategoryItem {
     
     init?(information: [String: Any]) {
-        guard let id = information[Key.id] as? Int,
+        guard let id = information[Key.id] as? String,
               let name = information[Key.name] as? String,
               let continued = information[Key.continued] as? Int
         else {
@@ -51,7 +39,8 @@ extension CategoryItem {
         var information: [String: Any] = [
             Key.id: id,
             Key.name: name,
-            Key.continued: continued
+            Key.continued: continued,
+            Key.createdAt: Date()
         ]
         if let lastChallenged {
             information[Key.lastChallenged] = lastChallenged
@@ -81,6 +70,7 @@ private extension CategoryItem {
         static let name = "name"
         static let continued = "continued"
         static let lastChallenged = "lastChallenged"
+        static let createdAt = "createdAt"
     }
 }
 

--- a/RefactorMoti/RefactorMoti/Domain/Entity/CategoryItem.swift
+++ b/RefactorMoti/RefactorMoti/Domain/Entity/CategoryItem.swift
@@ -28,9 +28,24 @@ struct CategoryItem: Hashable {
 }
 
 
-// MARK: - Dictionary
+// MARK: - Information
 
 extension CategoryItem {
+    
+    init?(information: [String: Any]) {
+        guard let id = information[Key.id] as? Int,
+              let name = information[Key.name] as? String,
+              let continued = information[Key.continued] as? Int
+        else {
+            return nil
+        }
+        let lastChallenged = information[Key.lastChallenged] as? Date
+        
+        self.id = id
+        self.name = name
+        self.continued = continued
+        self.lastChallenged = lastChallenged
+    }
     
     func toInformation() -> [String: Any] {
         var information: [String: Any] = [

--- a/RefactorMoti/RefactorMoti/Domain/StorageProtocol/FirebaseStorageProtocol.swift
+++ b/RefactorMoti/RefactorMoti/Domain/StorageProtocol/FirebaseStorageProtocol.swift
@@ -9,7 +9,13 @@ import Foundation
 
 protocol FirebaseStorageProtocol {
     
+    // Configure
     func configure()
+    
+    // Version
     func fetchVersion() async -> (latest: String, forced: String)?
+    
+    // Category
     func createDefaultCategories() async -> Bool
+    func fetchCategories() async throws -> [CategoryItem]
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewController.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewController.swift
@@ -75,7 +75,7 @@ private extension HomeViewController {
         layoutView.addCategoryButtonDidTap
             .sink { [weak self] in
                 guard let self else { return }
-                input.addCategory.send(CategoryItem(id: UUID().hashValue, name: "임시"))
+                input.addCategory.send(CategoryItem(id: UUID().uuidString, name: "임시"))
             }
             .store(in: &cancellables)
     }

--- a/RefactorMoti/RefactorMotiTests/Data/Repository/CategoryRepositoryTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Data/Repository/CategoryRepositoryTests.swift
@@ -10,8 +10,8 @@ import XCTest
 
 final class CategoryRepositoryTests: XCTestCase {
     
-    private let defaultCategories = [CategoryItem(id: 0, name: "전체"), CategoryItem(id: 1, name: "미설정")]
-    private let customCategory = CategoryItem(id: 2, name: "음식")
+    private let defaultCategories = [CategoryItem(id: "0", name: "전체"), CategoryItem(id: "1", name: "미설정")]
+    private let customCategory = CategoryItem(id: "2", name: "음식")
     
     
     // MARK: - Fetch Categories

--- a/RefactorMoti/RefactorMotiTests/Data/Repository/CategoryRepositoryTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Data/Repository/CategoryRepositoryTests.swift
@@ -48,7 +48,7 @@ final class CategoryRepositoryTests: XCTestCase {
     func test_addCategory에_성공하면_true를_반환한다() async throws {
         // given
         let repository = DefaultCategoryRepositoryStub()
-        let category = CategoryItem(id: 3, name: "카테고리")
+        let category = CategoryItem(id: "3", name: "카테고리")
         
         // when
         let isSuccess = await repository.addCategory(category)

--- a/RefactorMoti/RefactorMotiTests/Domain/UseCase/AddCategoryUseCaseTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Domain/UseCase/AddCategoryUseCaseTests.swift
@@ -13,7 +13,7 @@ final class AddCategoryUseCaseTests: XCTestCase {
     func test_카테고리_추가에_성공하면_true를_반환한다() async throws { 
         // given
         let useCase = AddCategoryUseCase(repository: DefaultCategoryRepositoryStub())
-        let categoryItem = CategoryItem(id: 2, name: "음식")
+        let categoryItem = CategoryItem(id: "2", name: "음식")
         
         // when
         let isSuccess = await useCase.execute(with: categoryItem)

--- a/RefactorMoti/RefactorMotiTests/Domain/UseCase/FetchCategoriesUseCaseTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Domain/UseCase/FetchCategoriesUseCaseTests.swift
@@ -10,8 +10,8 @@ import XCTest
 
 final class FetchCategoriesUseCaseTests: XCTestCase {
 
-    private let defaultCategories = [CategoryItem(id: 0, name: "전체"), CategoryItem(id: 1, name: "미설정")]
-    private let customCategory = CategoryItem(id: 2, name: "음식")
+    private let defaultCategories = [CategoryItem(id: "0", name: "전체"), CategoryItem(id: "1", name: "미설정")]
+    private let customCategory = CategoryItem(id: "2", name: "음식")
     
     func test_기본_카테고리만_있을_때_fetchCategories_수행이_성공하면_기본_리스트를_반환한다() async throws { 
         // given

--- a/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
@@ -97,7 +97,7 @@ final class HomeViewModelTests: XCTestCase {
         // given
         let expectation = XCTestExpectation()
         let expectation2 = XCTestExpectation()
-        let newCategory = CategoryItem(id: 99, name: "Test")
+        let newCategory = CategoryItem(id: "99", name: "Test")
         let targetNewCategories = targetCategories + [newCategory]
         
         // when

--- a/RefactorMoti/RefactorMotiTests/Stub/Repository/AchievementRepositoryStub.swift
+++ b/RefactorMoti/RefactorMotiTests/Stub/Repository/AchievementRepositoryStub.swift
@@ -23,7 +23,7 @@ struct AchievementRepositoryStub: AchievementRepositoryProtocol {
                 id: $0,
                 userID: $0,
                 imageURL: URL(string: "https://picsum.photos/500"),
-                category: CategoryItem(id: $0, name: "카테고리\($0)"),
+                category: CategoryItem(id: "\($0)", name: "카테고리\($0)"),
                 title: "제목\($0)",
                 createdAt: Date()
             )

--- a/RefactorMoti/RefactorMotiTests/Stub/Repository/CategoryRepositoryStub.swift
+++ b/RefactorMoti/RefactorMotiTests/Stub/Repository/CategoryRepositoryStub.swift
@@ -11,8 +11,8 @@ import Foundation
 struct DefaultCategoryRepositoryStub: CategoryRepositoryProtocol {
     
     private(set) var categories: [CategoryItem] = [
-        CategoryItem(id: 0, name: "전체"),
-        CategoryItem(id: 1, name: "미설정")
+        CategoryItem(id: "0", name: "전체"),
+        CategoryItem(id: "1", name: "미설정")
     ]
     
     func fetchCategories() async throws -> [CategoryItem] {
@@ -33,9 +33,9 @@ struct DefaultCategoryRepositoryStub: CategoryRepositoryProtocol {
 struct CustomCategoryRepositoryStub: CategoryRepositoryProtocol {
     
     private(set) var categories: [CategoryItem] = [
-        CategoryItem(id: 0, name: "전체"),
-        CategoryItem(id: 1, name: "미설정"),
-        CategoryItem(id: 2, name: "음식")
+        CategoryItem(id: "0", name: "전체"),
+        CategoryItem(id: "1", name: "미설정"),
+        CategoryItem(id: "2", name: "음식")
     ]
     
     func fetchCategories() async throws -> [CategoryItem] {

--- a/RefactorMoti/RefactorMotiTests/Stub/Storage/FirebaseStorageStub.swift
+++ b/RefactorMoti/RefactorMotiTests/Stub/Storage/FirebaseStorageStub.swift
@@ -19,4 +19,8 @@ struct FirebaseStorageStub: FirebaseStorageProtocol {
     func createDefaultCategories() async -> Bool {
         true
     }
+    
+    func fetchCategories() async throws -> [CategoryItem] {
+        []
+    }
 }


### PR DESCRIPTION
## Overview
- Firebase에 저장되는 카테고리 데이터에 createAt을 추가하였습니다.
- Firebase에서 카테고리 리스트를 가져오도록 수정했습니다.
  - createAt을 기준으로 오름차순 정렬하도록 구현했습니다.
- CategoryItem의 id를 String으로 바꿨습니다.
  - Firebase의 autoID를 사용하기 위해 변경하였습니다.

## Issue
closed #83 
