### PR TITLE
[#100] 카테고리를 추가하면 생성된 카테고리 모델을 반환한다.

### DIFF
--- a/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
+++ b/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
@@ -47,22 +47,28 @@ final class FirebaseStorage: FirebaseStorageProtocol {
             return true
         }
         
-        var isComplete = true
-        for category in Constant.defaultCategories where isComplete {
-            isComplete = await addCategory(name: category)
+        for category in Constant.defaultCategories {
+            if await addCategory(name: category) == nil {
+                return false
+            }
         }
-        return isComplete
+        return true
     }
     
-    func addCategory(name: String) async -> Bool {
+    func addCategory(name: String) async -> CategoryItem? {
         guard let categoryRef = userRef?.child(Path.category),
               let autoID = categoryRef.childByAutoId().key else {
-            return false
+            return nil
         }
         
-        let information = CategoryItem(id: autoID, name: name).toInformation()
-        let result = try? await categoryRef.child(autoID).setValue(information)
-        return result != nil
+        let newCategoryItem = CategoryItem(id: autoID, name: name)
+        let information = newCategoryItem.toInformation()
+        do {
+            try await categoryRef.child(autoID).setValue(information)
+            return newCategoryItem
+        } catch {
+            return nil
+        }
     }
     
     func fetchCategories() async throws -> [CategoryItem] {

--- a/RefactorMoti/RefactorMoti/Data/Repository/CategoryRepository.swift
+++ b/RefactorMoti/RefactorMoti/Data/Repository/CategoryRepository.swift
@@ -9,16 +9,16 @@ import Foundation
 
 struct CategoryRepository: CategoryRepositoryProtocol {
     
-    func fetchCategories() async throws -> [CategoryItem] {
-        try await firebaseStorage.fetchCategories()
+    func createDefaultCategories() async -> Bool {
+        await firebaseStorage.createDefaultCategories()
     }
     
-    func addCategory(name: String) async -> Bool {
+    func addCategory(name: String) async -> CategoryItem? {
         await firebaseStorage.addCategory(name: name)
     }
     
-    func createDefaultCategories() async -> Bool {
-        await firebaseStorage.createDefaultCategories()
+    func fetchCategories() async throws -> [CategoryItem] {
+        try await firebaseStorage.fetchCategories()
     }
     
     

--- a/RefactorMoti/RefactorMoti/Domain/RepositoryProtocol/CategoryRepositoryProtocol.swift
+++ b/RefactorMoti/RefactorMoti/Domain/RepositoryProtocol/CategoryRepositoryProtocol.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol CategoryRepositoryProtocol {
     
-    func fetchCategories() async throws -> [CategoryItem]
-    func addCategory(name: String) async -> Bool
     func createDefaultCategories() async -> Bool
+    func addCategory(name: String) async -> CategoryItem?
+    func fetchCategories() async throws -> [CategoryItem]
 }

--- a/RefactorMoti/RefactorMoti/Domain/StorageProtocol/FirebaseStorageProtocol.swift
+++ b/RefactorMoti/RefactorMoti/Domain/StorageProtocol/FirebaseStorageProtocol.swift
@@ -17,6 +17,6 @@ protocol FirebaseStorageProtocol {
     
     // Category
     func createDefaultCategories() async -> Bool
-    func addCategory(name: String) async -> Bool
+    func addCategory(name: String) async -> CategoryItem?
     func fetchCategories() async throws -> [CategoryItem]
 }

--- a/RefactorMoti/RefactorMoti/Domain/UseCase/AddCategoryUseCase.swift
+++ b/RefactorMoti/RefactorMoti/Domain/UseCase/AddCategoryUseCase.swift
@@ -9,14 +9,14 @@ import Foundation
 
 protocol AddCategoryUseCaseProtocol {
     
-    func execute(with categoryName: String) async -> Bool
+    func execute(with categoryName: String) async -> CategoryItem?
 }
 
 struct AddCategoryUseCase: AddCategoryUseCaseProtocol {
     
     // MARK: - Interface
     
-    func execute(with categoryName: String) async -> Bool {
+    func execute(with categoryName: String) async -> CategoryItem? {
         await repository.addCategory(name: categoryName)
     }
     

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
@@ -95,8 +95,15 @@ private extension HomeViewModel {
     
     func addCategory(name: String) {
         Task {
-            let isSuccess = await addCategoryUseCase.execute(with: name)
-            output.isAddedCategorySuccess.send(isSuccess)
+            guard let addedCategoryItem = await addCategoryUseCase.execute(with: name) else {
+                output.isAddedCategorySuccess.send(false)
+                return
+            }
+            output.isAddedCategorySuccess.send(true)
+            
+            let newCategories = categories + [addedCategoryItem]
+            categoryDataSource?.update(data: newCategories)
+            output.categories.send(newCategories)
         }
     }
     

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
@@ -29,14 +29,12 @@ final class HomeViewModel {
     private var categoryDataSource: CategoryDataSource?
     private var achievementDataSource: AchievementDataSource?
     
-    // MARK: UseCase
-    
+    // UseCase
+    private let addCategoryUseCase: AddCategoryUseCaseProtocol
     private let fetchCategoriesUseCase: FetchCategoriesUseCaseProtocol
     private let fetchAchievementsUseCase: FetchAchievementsUseCaseProtocol
-    private let addCategoryUseCase: AddCategoryUseCaseProtocol
     
-    // MARK: Output
-    
+    // Output
     let output = Output()
     private var cancellables: Set<AnyCancellable> = []
     
@@ -48,13 +46,13 @@ final class HomeViewModel {
     // MARK: - Initializer
     
     init(
+        addCategoryUseCase: AddCategoryUseCaseProtocol = AddCategoryUseCase(),
         fetchCategoriesUseCase: FetchCategoriesUseCaseProtocol = FetchCategoriesUseCase(),
-        fetchAchievementsUseCase: FetchAchievementsUseCaseProtocol = FetchAchievementsUseCase(),
-        addCategoryUseCase: AddCategoryUseCaseProtocol = AddCategoryUseCase()
+        fetchAchievementsUseCase: FetchAchievementsUseCaseProtocol = FetchAchievementsUseCase()
     ) {
+        self.addCategoryUseCase = addCategoryUseCase
         self.fetchCategoriesUseCase = fetchCategoriesUseCase
         self.fetchAchievementsUseCase = fetchAchievementsUseCase
-        self.addCategoryUseCase = addCategoryUseCase
     }
 }
 

--- a/RefactorMoti/RefactorMotiTests/Data/Repository/CategoryRepositoryTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Data/Repository/CategoryRepositoryTests.swift
@@ -51,9 +51,9 @@ final class CategoryRepositoryTests: XCTestCase {
         let categoryName = "카테고리"
         
         // when
-        let isSuccess = await repository.addCategory(name: categoryName)
+        let addedCategoryItem = await repository.addCategory(name: categoryName)
         
         // then
-        XCTAssertTrue(isSuccess)
+        XCTAssertNotNil(addedCategoryItem)
     }
 }

--- a/RefactorMoti/RefactorMotiTests/Domain/UseCase/AddCategoryUseCaseTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Domain/UseCase/AddCategoryUseCaseTests.swift
@@ -16,10 +16,10 @@ final class AddCategoryUseCaseTests: XCTestCase {
         let categoryName = "음식"
         
         // when
-        let isSuccess = await useCase.execute(with: categoryName)
+        let addedCategoryItem = await useCase.execute(with: categoryName)
         
         // then
-        XCTAssertTrue(isSuccess)
+        XCTAssertNotNil(addedCategoryItem)
     }
     
     func test_카테고리_추가에_실패하면_false를_반환한다() async throws { }

--- a/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
@@ -13,6 +13,7 @@ final class HomeViewModelTests: XCTestCase {
  
     // MARK: - Attribute
     
+    private let addCategoryUseCase = AddCategoryUseCase(repository: DefaultCategoryRepositoryStub())
     private let fetchCategoriesUseCase = FetchCategoriesUseCase(repository: DefaultCategoryRepositoryStub())
     private let fetchAchievementsUseCase = FetchAchievementsUseCase(repository: AchievementRepositoryStub())
     
@@ -29,6 +30,7 @@ final class HomeViewModelTests: XCTestCase {
     
     override func setUp() async throws {
         viewModel = HomeViewModel(
+            addCategoryUseCase: addCategoryUseCase,
             fetchCategoriesUseCase: fetchCategoriesUseCase,
             fetchAchievementsUseCase: fetchAchievementsUseCase
         )

--- a/RefactorMoti/RefactorMotiTests/Stub/Repository/CategoryRepositoryStub.swift
+++ b/RefactorMoti/RefactorMotiTests/Stub/Repository/CategoryRepositoryStub.swift
@@ -15,18 +15,19 @@ struct DefaultCategoryRepositoryStub: CategoryRepositoryProtocol {
         CategoryItem(id: "1", name: "미설정")
     ]
     
-    func fetchCategories() async throws -> [CategoryItem] {
-        categories
-    }
-    
-    func addCategory(name: String) async -> Bool {
-        var mutable = categories
-        mutable.append(CategoryItem(id: "99", name: name))
-        return true
-    }
-    
     func createDefaultCategories() async -> Bool {
         true
+    }
+    
+    func addCategory(name: String) async -> CategoryItem? {
+        let newCategoryItem = CategoryItem(id: "99", name: name)
+        var mutable = categories
+        mutable.append(newCategoryItem)
+        return newCategoryItem
+    }
+    
+    func fetchCategories() async throws -> [CategoryItem] {
+        categories
     }
 }
 
@@ -38,17 +39,18 @@ struct CustomCategoryRepositoryStub: CategoryRepositoryProtocol {
         CategoryItem(id: "2", name: "음식")
     ]
     
-    func fetchCategories() async throws -> [CategoryItem] {
-        categories
-    }
-    
-    func addCategory(name: String) async -> Bool {
-        var mutable = categories
-        mutable.append(CategoryItem(id: "99", name: name))
-        return true
-    }
-    
     func createDefaultCategories() async -> Bool {
         true
+    }
+    
+    func addCategory(name: String) async -> CategoryItem? {
+        let newCategoryItem = CategoryItem(id: "99", name: name)
+        var mutable = categories
+        mutable.append(newCategoryItem)
+        return newCategoryItem
+    }
+    
+    func fetchCategories() async throws -> [CategoryItem] {
+        categories
     }
 }

--- a/RefactorMoti/RefactorMotiTests/Stub/Storage/FirebaseStorageStub.swift
+++ b/RefactorMoti/RefactorMotiTests/Stub/Storage/FirebaseStorageStub.swift
@@ -20,8 +20,8 @@ struct FirebaseStorageStub: FirebaseStorageProtocol {
         true
     }
     
-    func addCategory(name: String) async -> Bool {
-        true
+    func addCategory(name: String) async -> CategoryItem? {
+        CategoryItem(id: "", name: name)
     }
     
     func fetchCategories() async throws -> [CategoryItem] {


### PR DESCRIPTION
## Overview
카테고리를 추가하면 생성된 카테고리 모델을 반환하도록 수정하였습니다.
반환된 카테고리를 이용해 HomeViewController의 Category CollectionView를 업데이트 합니다.

## Diagram
![moti2-3-2](https://github.com/jeongju9216/moti-2.0/assets/89075274/595567a1-4994-4db8-bc8d-641acbe118bd)

## Note
카테고리 추가 기능을 Firebase와 연결하면서 많은 느낀 점이 있습니다.

### 구조의 중요성
Firebase에 카테고리를 추가할 때 카테고리를 어떻게 저장할지 고민이 선행되지 않았습니다.
그 결과, 두 번에 걸쳐 수정 작업이 필요했습니다. 조금만 고민했다면 이런 불필요한 작업을 줄일 수 있었을 겁니다.
iOS 기술만 고민하지 말고, 나의 프로젝트 전반적인 고민이 필요하다는 것을 깨달았습니다.

### PR과 커밋 단위
PR과 커밋 단위에 대해 고민했습니다.
A 작업을 진행하던 도중 B 버그를 발견하면 어떻게 분리를 해야할까?
그 PR에서 진행을 해야할까? 아니면 새로운 티켓을 만들어야 할까?
이번에는 하나의 PR에서 진행하고 커밋을 분리했지만, 이렇게 진행하니 버그를 수정한 PR을 찾기 어렵다는 단점이 있었습니다.
그렇다고 다른 PR에서 진행한다면 수정하기 전에 올리는 PR에는 버그가 살아있는 상태로 진행됩니다.
둘 다 적절히 섞어 진행해보면서 장단점을 느껴보려고 합니다.

### 다이어그램 업데이트
다이어그램은 변화가 생길 때마다 업데이트 하자,,, ㅎㅎ;;
지금처럼 한 번에 하지 말고....
현재 PR에서 바뀐 부분도 별도로 표시할 수 있는 방법을 찾아보자

## Issue
closed #100 
