### PR TITLE
[#102] 도전기록 리스트를 Firebase에서 가져와서 표시한다.

### DIFF
--- a/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
+++ b/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
@@ -111,8 +111,14 @@ final class FirebaseStorage: FirebaseStorageProtocol {
         }
         return isExistData.childrenCount < 2
     }
+}
+
+
+// MARK: - Fetch Data
+
+private extension FirebaseStorage {
     
-    private func fetchData(from path: String) async throws -> DataSnapshot {
+    func fetchData(from path: String) async throws -> DataSnapshot {
         guard let userRef else {
             throw FirebaseStorageError.nonexistUserReference
         }
@@ -127,7 +133,7 @@ final class FirebaseStorage: FirebaseStorageProtocol {
         }
     }
     
-    private func fetchSortedData(
+    func fetchSortedData(
         from path: String,
         sortBy key: String = Path.createdAt
     ) async throws -> DataSnapshot {

--- a/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
+++ b/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
@@ -90,12 +90,13 @@ final class FirebaseStorage: FirebaseStorageProtocol {
         for child in dataSnapshot.children {
             guard let snapshot = child as? DataSnapshot,
                   var information = snapshot.value as? [String: Any],
-                  let categoryID = information["categoryID"] as? String,
-                  let category = await fetchCategoryItem(id: categoryID)
+                  let categoryID = information["categoryID"] as? String
             else {
                 continue
             }
-            information["category"] = category
+            
+            async let category = fetchCategoryItem(id: categoryID)
+            await information["category"] = category
             
             if let achievement = Achievement(information: information) {
                 achievements.append(achievement)

--- a/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
+++ b/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
@@ -82,6 +82,12 @@ final class FirebaseStorage: FirebaseStorageProtocol {
         }
     }
     
+    // MARK: Achievement
+    
+    func fetchAllAchievement() async throws -> [Achievement] {
+        []
+    }
+    
     
     // MARK: - Attribute
     

--- a/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
+++ b/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
@@ -72,7 +72,7 @@ final class FirebaseStorage: FirebaseStorageProtocol {
     }
     
     func fetchCategories() async throws -> [CategoryItem] {
-        let categorySnapshot = try await fetchSortedData(from: Path.category)
+        let categorySnapshot = try await fetchSortedDataSnapshot(from: Path.category)
         return categorySnapshot.children.compactMap { child in
             guard let snapshot = child as? DataSnapshot,
                   let information = snapshot.value as? [String: Any] else {
@@ -118,7 +118,7 @@ final class FirebaseStorage: FirebaseStorageProtocol {
 
 private extension FirebaseStorage {
     
-    func fetchData(from path: String) async throws -> DataSnapshot {
+    func fetchDataSnapshot(from path: String) async throws -> DataSnapshot {
         guard let userRef else {
             throw FirebaseStorageError.nonexistUserReference
         }
@@ -133,7 +133,7 @@ private extension FirebaseStorage {
         }
     }
     
-    func fetchSortedData(
+    func fetchSortedDataSnapshot(
         from path: String,
         sortBy key: String = Path.createdAt
     ) async throws -> DataSnapshot {
@@ -167,6 +167,7 @@ private extension FirebaseStorage {
         
         static let category = "category"
         static let createdAt = "createdAt"
+        static let achievement = "achievement"
     }
 }
 

--- a/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
+++ b/RefactorMoti/RefactorMoti/Data/Firebase/FirebaseStorage.swift
@@ -74,8 +74,7 @@ final class FirebaseStorage: FirebaseStorageProtocol {
     func fetchCategories() async throws -> [CategoryItem] {
         let categorySnapshot = try await fetchSortedDataSnapshot(from: Path.category)
         return categorySnapshot.children.compactMap { child in
-            guard let snapshot = child as? DataSnapshot,
-                  let information = snapshot.value as? [String: Any] else {
+            guard let information = makeInformation(of: child) else {
                 return nil
             }
             return CategoryItem(information: information)
@@ -88,8 +87,7 @@ final class FirebaseStorage: FirebaseStorageProtocol {
         let dataSnapshot = try await fetchSortedDataSnapshot(from: Path.achievement)
         var achievements: [Achievement] = []
         for child in dataSnapshot.children {
-            guard let snapshot = child as? DataSnapshot,
-                  var information = snapshot.value as? [String: Any],
+            guard var information = makeInformation(of: child),
                   let categoryID = information["categoryID"] as? String
             else {
                 continue
@@ -144,6 +142,13 @@ final class FirebaseStorage: FirebaseStorageProtocol {
 // MARK: - Fetch Data
 
 private extension FirebaseStorage {
+    
+    func makeInformation(of child: NSEnumerator.Element) -> [String: Any]? {
+        guard let snapshot = child as? DataSnapshot else {
+            return nil
+        }
+        return snapshot.value as? [String: Any]
+    }
     
     func fetchDataSnapshot(from path: String) async throws -> DataSnapshot {
         guard let userRef else {

--- a/RefactorMoti/RefactorMoti/Data/Repository/AchievementRepository.swift
+++ b/RefactorMoti/RefactorMoti/Data/Repository/AchievementRepository.swift
@@ -9,15 +9,21 @@ import Foundation
 
 struct AchievementRepository: AchievementRepositoryProtocol { 
     
+    // MARK: - Interface
+    
     func fetchAchievements() async throws -> [Achievement] {
-        (0..<10).map {
-            Achievement(
-                id: "\($0)",
-                imageURL: URL(string: "https://picsum.photos/500"),
-                category: CategoryItem(id: "\($0)", name: "카테고리\($0)"),
-                title: "제목\($0)",
-                createdAt: Date()
-            )
-        }
+        try await firebaseStorage.fetchAllAchievement()
+    }
+    
+    
+    // MARK: - Attribute
+    
+    private let firebaseStorage: FirebaseStorageProtocol
+    
+    
+    // MARK: - Initializer
+    
+    init(firebaseStorage: FirebaseStorageProtocol = FirebaseStorage.shared) {
+        self.firebaseStorage = firebaseStorage
     }
 }

--- a/RefactorMoti/RefactorMoti/Data/Repository/AchievementRepository.swift
+++ b/RefactorMoti/RefactorMoti/Data/Repository/AchievementRepository.swift
@@ -12,8 +12,7 @@ struct AchievementRepository: AchievementRepositoryProtocol {
     func fetchAchievements() async throws -> [Achievement] {
         (0..<10).map {
             Achievement(
-                id: $0,
-                userID: $0,
+                id: "\($0)",
                 imageURL: URL(string: "https://picsum.photos/500"),
                 category: CategoryItem(id: "\($0)", name: "카테고리\($0)"),
                 title: "제목\($0)",

--- a/RefactorMoti/RefactorMoti/Domain/Entity/Achievement.swift
+++ b/RefactorMoti/RefactorMoti/Domain/Entity/Achievement.swift
@@ -25,22 +25,20 @@ extension Achievement {
     init?(information: [String: Any]) {
         guard let id = information[Key.id] as? String,
               let imageURLString = information[Key.imageURL] as? String,
-              let imageURL = URL(string: imageURLString),
-              let categoryInformation = information[Key.category] as? [String: Any],
-              let category = CategoryItem(information: categoryInformation),
+              let category = information[Key.category] as? CategoryItem,
               let title = information[Key.title] as? String,
-              let createdAt = information[Key.createdAt] as? Date
+              let createdAt = information[Key.createdAt] as? TimeInterval
         else {
             return nil
         }
         let body = information[Key.body] as? String
         
         self.id = id
-        self.imageURL = imageURL
+        self.imageURL = URL(string: imageURLString)
         self.category = category
         self.title = title
         self.body = body
-        self.createdAt = createdAt
+        self.createdAt = Date(timeIntervalSince1970: createdAt)
     }
 }
 

--- a/RefactorMoti/RefactorMoti/Domain/Entity/Achievement.swift
+++ b/RefactorMoti/RefactorMoti/Domain/Entity/Achievement.swift
@@ -9,11 +9,53 @@ import Foundation
 
 struct Achievement: Hashable {
     
-    let id: Int
-    let userID: Int
+    let id: String
     let imageURL: URL?
     var category: CategoryItem
     var title: String
     var body: String?
     let createdAt: Date?
+}
+
+
+// MARK: - Information
+
+extension Achievement {
+    
+    init?(information: [String: Any]) {
+        guard let id = information[Key.id] as? String,
+              let imageURLString = information[Key.imageURL] as? String,
+              let imageURL = URL(string: imageURLString),
+              let categoryInformation = information[Key.category] as? [String: Any],
+              let category = CategoryItem(information: categoryInformation),
+              let title = information[Key.title] as? String,
+              let createdAt = information[Key.createdAt] as? Date
+        else {
+            return nil
+        }
+        let body = information[Key.body] as? String
+        
+        self.id = id
+        self.imageURL = imageURL
+        self.category = category
+        self.title = title
+        self.body = body
+        self.createdAt = createdAt
+    }
+}
+
+
+// MARK: - Constant
+
+private extension Achievement {
+    
+    enum Key {
+        
+        static let id = "id"
+        static let imageURL = "imageURL"
+        static let category = "category"
+        static let title = "title"
+        static let body = "body"
+        static let createdAt = "createdAt"
+    }
 }

--- a/RefactorMoti/RefactorMoti/Domain/StorageProtocol/FirebaseStorageProtocol.swift
+++ b/RefactorMoti/RefactorMoti/Domain/StorageProtocol/FirebaseStorageProtocol.swift
@@ -19,4 +19,7 @@ protocol FirebaseStorageProtocol {
     func createDefaultCategories() async -> Bool
     func addCategory(name: String) async -> CategoryItem?
     func fetchCategories() async throws -> [CategoryItem]
+    
+    // Achievement
+    func fetchAllAchievement() async throws -> [Achievement]
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewController.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewController.swift
@@ -48,25 +48,11 @@ final class HomeViewController: LayoutViewController<HomeView> {
 private extension HomeViewController {
 
     private func setUpViewModelBinding() {
-        output.categories
-            .sink { [weak self] categories in
-                guard let self else { return }
-                print("categories: \(categories)") // swiftlint:disable:this all
-            }
-            .store(in: &cancellables)
-        
         output.selectedCategoryIndex
             .receive(on: DispatchQueue.main)
             .sink { [weak self] indexPath in
                 guard let self else { return }
                 layoutView.selectCategory(indexPath: indexPath)
-            }
-            .store(in: &cancellables)
-        
-        output.achievements
-            .sink { [weak self] achievements in
-                guard let self else { return }
-                print("achievements: \(achievements)") // swiftlint:disable:this all
             }
             .store(in: &cancellables)
     }

--- a/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
@@ -148,7 +148,6 @@ final class HomeViewModelTests: XCTestCase {
         let expectation2 = XCTestExpectation()
         let targetIndex = 1
         let targetIndexPath = IndexPath(row: targetIndex, section: 0)
-        let target = targetCategories[targetIndex]
         
         // when
         var source: IndexPath?
@@ -186,8 +185,7 @@ final class HomeViewModelTests: XCTestCase {
         // when
         var source: [Achievement]?
         output.achievements
-            .sink { [weak self] achievements in
-                guard let self else { return }
+            .sink { achievements in
                 source = achievements
                 expectation.fulfill()
             }

--- a/RefactorMoti/RefactorMotiTests/Stub/Repository/AchievementRepositoryStub.swift
+++ b/RefactorMoti/RefactorMotiTests/Stub/Repository/AchievementRepositoryStub.swift
@@ -20,8 +20,7 @@ struct AchievementRepositoryStub: AchievementRepositoryProtocol {
     func fetchAchievements() async throws -> [Achievement] {
         (0..<10).map {
             Achievement(
-                id: $0,
-                userID: $0,
+                id: "\($0)",
                 imageURL: URL(string: "https://picsum.photos/500"),
                 category: CategoryItem(id: "\($0)", name: "카테고리\($0)"),
                 title: "제목\($0)",

--- a/RefactorMoti/RefactorMotiTests/Stub/Storage/FirebaseStorageStub.swift
+++ b/RefactorMoti/RefactorMotiTests/Stub/Storage/FirebaseStorageStub.swift
@@ -27,4 +27,8 @@ struct FirebaseStorageStub: FirebaseStorageProtocol {
     func fetchCategories() async throws -> [CategoryItem] {
         []
     }
+    
+    func fetchAllAchievement() async throws -> [Achievement] {
+        []
+    }
 }


### PR DESCRIPTION
## Overview
도전기록 리스트를 Firebase에서 가져와서 표시하도록 구현했습니다.
파이어베이스의 도전기록 데이터는 임시로 직접 추가하였습니다.

## Note
### Achievement 구조 고민
https://github.com/jeongju9216/moti-2.0/pull/101 에서 반성한 것처럼 이번에는 구조를 고민하고 개발을 했습니다.
불필요한 과정이 확실히 줄었다고 느껴졌습니다.

다만, 구조를 잡으면서 생긴 고민이 있었는데요.
구조의 중첩을 피할 것인지, 클라이언트의 조회 횟수를 줄일 것인지 고민했습니다.
파이어베이스 공식 문서에서는 모델을 중첩하는 것을 피하라고 적혀 있는데요. (모든 하위 노드를 가져오기 때문에 비효율적임)
<img width="515" alt="스크린샷 2024-05-12 14 17 38" src="https://github.com/jeongju9216/moti-2.0/assets/89075274/0b1d5ec8-430f-4281-9699-dfd6dc8066e1">
그래서 위처럼 카테고리와 도전기록을 분리하여 저장하였습니다.
도전기록에 카테고리 ID를 넣어서 iOS 코드에서 다시 조회하는 형식이에요.
고민했던 건
1. 지금처럼 평면화해서 구조가 중첩되지 않도록 하는게 효율적일지,
2. 클라이언트에서 한 번만 조회할 수 있도록 구조를 잡는게 효율적인지
사이에서 고민했습니다.
지금은 공식 가이드의 권장대로 1번을 선택했지만, 주변 동료들에게 한 번 물어보면서 시야를 넓혀야겠다고 생각했습니다.

## Issue
closed #102 
