### PR TITLE
[#112] Achievement를 등록하는 UseCase, ViewModel을 구현한다. (이미지 제외)

### DIFF
--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		9B95D92D2BF0C417003BFDC3 /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D92C2BF0C417003BFDC3 /* UserRepository.swift */; };
 		9B95D92F2BF0C7CE003BFDC3 /* AutoLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D92E2BF0C7CE003BFDC3 /* AutoLoginUseCase.swift */; };
 		9B95D9322BF21995003BFDC3 /* AchievementRequestValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D9312BF21995003BFDC3 /* AchievementRequestValue.swift */; };
+		9B95D9342BF22E47003BFDC3 /* AddAchievementUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D9332BF22E47003BFDC3 /* AddAchievementUseCase.swift */; };
 		9BA895872BDFDB5B0080D400 /* JeongDesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 9BA895862BDFDB5B0080D400 /* JeongDesignSystem */; };
 		9BA8958C2BE11C820080D400 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA8958B2BE11C820080D400 /* HomeViewModelTests.swift */; };
 		9BA895992BE387870080D400 /* AchievementRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895982BE387870080D400 /* AchievementRepositoryTests.swift */; };
@@ -155,6 +156,7 @@
 		9B95D92C2BF0C417003BFDC3 /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
 		9B95D92E2BF0C7CE003BFDC3 /* AutoLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLoginUseCase.swift; sourceTree = "<group>"; };
 		9B95D9312BF21995003BFDC3 /* AchievementRequestValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRequestValue.swift; sourceTree = "<group>"; };
+		9B95D9332BF22E47003BFDC3 /* AddAchievementUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAchievementUseCase.swift; sourceTree = "<group>"; };
 		9BA8958B2BE11C820080D400 /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
 		9BA895982BE387870080D400 /* AchievementRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepositoryTests.swift; sourceTree = "<group>"; };
 		9BA8959A2BE38CCA0080D400 /* AchievementRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepository.swift; sourceTree = "<group>"; };
@@ -419,6 +421,7 @@
 				9BA895DF2BE874D80080D400 /* AddCategoryUseCase.swift */,
 				9B95D9222BEF44AA003BFDC3 /* CreateDefaultCategoriesUseCase.swift */,
 				9B95D92E2BF0C7CE003BFDC3 /* AutoLoginUseCase.swift */,
+				9B95D9332BF22E47003BFDC3 /* AddAchievementUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -762,6 +765,7 @@
 				9B289C8D2BDE4687000813C1 /* LoginViewController.swift in Sources */,
 				9B4581832BD9341A002A32DC /* FirebaseStorageProtocol.swift in Sources */,
 				9B4581702BD7EB37002A32DC /* FirebaseStorage.swift in Sources */,
+				9B95D9342BF22E47003BFDC3 /* AddAchievementUseCase.swift in Sources */,
 				9B45816A2BD7EAE7002A32DC /* VersionRepositoryProtocol.swift in Sources */,
 				9B289C822BDD3B6C000813C1 /* AutoLayoutWrapper+Center.swift in Sources */,
 				9BA895C92BE673120080D400 /* CategoryItem.swift in Sources */,

--- a/RefactorMoti/RefactorMoti/Domain/UseCase/AddAchievementUseCase.swift
+++ b/RefactorMoti/RefactorMoti/Domain/UseCase/AddAchievementUseCase.swift
@@ -1,0 +1,34 @@
+//
+//  AddAchievementUseCase.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 5/13/24.
+//
+
+import Foundation
+
+protocol AddAchievementUseCaseProtocol {
+    
+    func execute(requestValue: AchievementRequestValue) async -> Achievement?
+}
+
+struct AddAchievementUseCase: AddAchievementUseCaseProtocol {
+    
+    // MARK: - Interface
+    
+    func execute(requestValue: AchievementRequestValue) async -> Achievement? {
+        await repository.addAchievement(requestValue: requestValue)
+    }
+    
+    
+    // MARK: - Attribute
+    
+    private let repository: AchievementRepositoryProtocol
+    
+    
+    // MARK: - Initializer
+    
+    init(repository: AchievementRepositoryProtocol = AchievementRepository()) {
+        self.repository = repository
+    }
+}

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
@@ -42,6 +42,9 @@ final class HomeViewModel {
     private var categories: [CategoryItem] {
         output.categories.value
     }
+    private var achievements: [Achievement] {
+        output.achievements.value
+    }
     
     
     // MARK: - Initializer
@@ -84,6 +87,13 @@ extension HomeViewModel {
                 selectCategory(at: indexPath)
             }
             .store(in: &cancellables)
+        
+        input.addAchievement
+            .sink { [weak self] achievementRequestValue in
+                guard let self else { return }
+                addAchievement(requestValue: achievementRequestValue)
+            }
+            .store(in: &cancellables)
     }
 }
 
@@ -102,10 +112,11 @@ private extension HomeViewModel {
                 output.isAddedCategorySuccess.send(false)
                 return
             }
-            output.isAddedCategorySuccess.send(true)
             
             let newCategories = categories + [addedCategoryItem]
             categoryDataSource?.update(data: newCategories)
+            
+            output.isAddedCategorySuccess.send(true)
             output.categories.send(newCategories)
         }
     }
@@ -116,6 +127,21 @@ private extension HomeViewModel {
         }
         
         output.selectedCategoryIndex.send(indexPath)
+    }
+    
+    func addAchievement(requestValue: AchievementRequestValue) {
+        Task {
+            guard let addedAchievement = await addAchievementUseCase.execute(requestValue: requestValue) else {
+                output.isAddedAchievementSuccess.send(false)
+                return
+            }
+            
+            let newAchievements = achievements + [addedAchievement]
+            achievementDataSource?.update(data: newAchievements)
+            
+            output.isAddedAchievementSuccess.send(true)
+            output.achievements.send(newAchievements)
+        }
     }
 }
 

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModel.swift
@@ -32,6 +32,7 @@ final class HomeViewModel {
     // UseCase
     private let addCategoryUseCase: AddCategoryUseCaseProtocol
     private let fetchCategoriesUseCase: FetchCategoriesUseCaseProtocol
+    private let addAchievementUseCase: AddAchievementUseCaseProtocol
     private let fetchAchievementsUseCase: FetchAchievementsUseCaseProtocol
     
     // Output
@@ -48,10 +49,12 @@ final class HomeViewModel {
     init(
         addCategoryUseCase: AddCategoryUseCaseProtocol = AddCategoryUseCase(),
         fetchCategoriesUseCase: FetchCategoriesUseCaseProtocol = FetchCategoriesUseCase(),
+        addAchievementUseCase: AddAchievementUseCaseProtocol = AddAchievementUseCase(),
         fetchAchievementsUseCase: FetchAchievementsUseCaseProtocol = FetchAchievementsUseCase()
     ) {
         self.addCategoryUseCase = addCategoryUseCase
         self.fetchCategoriesUseCase = fetchCategoriesUseCase
+        self.addAchievementUseCase = addAchievementUseCase
         self.fetchAchievementsUseCase = fetchAchievementsUseCase
     }
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModelInputOutput.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModelInputOutput.swift
@@ -12,22 +12,27 @@ extension HomeViewModel {
     
     struct Input {
         
+        // Life Cycle
         let viewDidLoad: PassthroughSubject<Void, Never> = .init()
+        
+        // Category
         let addCategory: PassthroughSubject<String, Never> = .init()
         let selectCategoryCell: PassthroughSubject<IndexPath, Never> = .init()
+        
+        // Achievement
+        let addAchievement: PassthroughSubject<String, Never> = .init()
     }
     
     struct Output {
         
-        // MARK: Category
-        
+        // Category
         let categories: CurrentValueSubject<[CategoryItem], Never> = .init([])
         let selectedCategoryIndex: PassthroughSubject<IndexPath, Never> = .init()
         let isAddedCategorySuccess: PassthroughSubject<Bool, Never> = .init()
         
-        // MARK: Achievement
-        
+        // Achievement
         let achievements: PassthroughSubject<[Achievement], Never> = .init()
+        let isAddedAchievementSuccess: PassthroughSubject<Bool, Never> = .init()
     }
 }
 

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModelInputOutput.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeViewModelInputOutput.swift
@@ -20,7 +20,7 @@ extension HomeViewModel {
         let selectCategoryCell: PassthroughSubject<IndexPath, Never> = .init()
         
         // Achievement
-        let addAchievement: PassthroughSubject<String, Never> = .init()
+        let addAchievement: PassthroughSubject<AchievementRequestValue, Never> = .init()
     }
     
     struct Output {
@@ -31,7 +31,7 @@ extension HomeViewModel {
         let isAddedCategorySuccess: PassthroughSubject<Bool, Never> = .init()
         
         // Achievement
-        let achievements: PassthroughSubject<[Achievement], Never> = .init()
+        let achievements: CurrentValueSubject<[Achievement], Never> = .init([])
         let isAddedAchievementSuccess: PassthroughSubject<Bool, Never> = .init()
     }
 }

--- a/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
@@ -15,6 +15,7 @@ final class HomeViewModelTests: XCTestCase {
     
     private let addCategoryUseCase = AddCategoryUseCase(repository: DefaultCategoryRepositoryStub())
     private let fetchCategoriesUseCase = FetchCategoriesUseCase(repository: DefaultCategoryRepositoryStub())
+    private let addAchievementUseCase = AddAchievementUseCase(repository: AchievementRepositoryStub())
     private let fetchAchievementsUseCase = FetchAchievementsUseCase(repository: AchievementRepositoryStub())
     
     private var targetCategories: [CategoryItem]!
@@ -32,6 +33,7 @@ final class HomeViewModelTests: XCTestCase {
         viewModel = HomeViewModel(
             addCategoryUseCase: addCategoryUseCase,
             fetchCategoriesUseCase: fetchCategoriesUseCase,
+            addAchievementUseCase: addAchievementUseCase,
             fetchAchievementsUseCase: fetchAchievementsUseCase
         )
         input = .init()
@@ -203,6 +205,12 @@ final class HomeViewModelTests: XCTestCase {
     func test_addAchievement가_input됐을_때_추가에_성공하면_output은_true() async throws {
         // given
         let expectation = XCTestExpectation()
+        let requestValue = AchievementRequestValue(
+            title: "",
+            body: "",
+            category: .init(id: "", name: ""),
+            imageURLString: ""
+        )
         
         // when
         var source: Bool?
@@ -213,7 +221,7 @@ final class HomeViewModelTests: XCTestCase {
             }
             .store(in: &cancellables)
         
-        input.addAchievement.send("")
+        input.addAchievement.send(requestValue)
         
         // then
         wait(for: [expectation], timeout: 5)
@@ -225,6 +233,20 @@ final class HomeViewModelTests: XCTestCase {
     func test_addAchievement가_input됐을_때_추가에_실패하면_output은_false() async throws {
         // given
         let expectation = XCTestExpectation()
+        let addAchievementUseCase = AddAchievementUseCase(repository: EmptyAchievementRepositoryStub())
+        viewModel = HomeViewModel(
+            addCategoryUseCase: addCategoryUseCase,
+            fetchCategoriesUseCase: fetchCategoriesUseCase,
+            addAchievementUseCase: addAchievementUseCase,
+            fetchAchievementsUseCase: fetchAchievementsUseCase
+        )
+        viewModel.bind(input: input)
+        let requestValue = AchievementRequestValue(
+            title: "",
+            body: "",
+            category: .init(id: "", name: ""),
+            imageURLString: ""
+        )
         
         // when
         var source: Bool?
@@ -235,13 +257,13 @@ final class HomeViewModelTests: XCTestCase {
             }
             .store(in: &cancellables)
         
-        input.addAchievement.send("")
+        input.addAchievement.send(requestValue)
         
         // then
         wait(for: [expectation], timeout: 5)
         
         XCTAssertNotNil(source)
-        XCTAssertTrue(source!)
+        XCTAssertFalse(source!)
     }
     
     func test_refresh가_input되면_사진_리스트를_output() throws { }

--- a/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
+++ b/RefactorMoti/RefactorMotiTests/Presentation/ViewModel/HomeViewModelTests.swift
@@ -200,6 +200,50 @@ final class HomeViewModelTests: XCTestCase {
         XCTAssertTrue(compareAchievement(source: source!, target: targetAchievements))
     }
     
+    func test_addAchievement가_input됐을_때_추가에_성공하면_output은_true() async throws {
+        // given
+        let expectation = XCTestExpectation()
+        
+        // when
+        var source: Bool?
+        output.isAddedAchievementSuccess
+            .sink { isAddedAchievementSuccess in
+                source = isAddedAchievementSuccess
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        input.addAchievement.send("")
+        
+        // then
+        wait(for: [expectation], timeout: 5)
+        
+        XCTAssertNotNil(source)
+        XCTAssertTrue(source!)
+    }
+    
+    func test_addAchievement가_input됐을_때_추가에_실패하면_output은_false() async throws {
+        // given
+        let expectation = XCTestExpectation()
+        
+        // when
+        var source: Bool?
+        output.isAddedAchievementSuccess
+            .sink { isAddedAchievementSuccess in
+                source = isAddedAchievementSuccess
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        input.addAchievement.send("")
+        
+        // then
+        wait(for: [expectation], timeout: 5)
+        
+        XCTAssertNotNil(source)
+        XCTAssertTrue(source!)
+    }
+    
     func test_refresh가_input되면_사진_리스트를_output() throws { }
     
     func test_deletePhoto가_input될_때_성공하면_output은_true() throws { }


### PR DESCRIPTION
## Overview
- Achievement를 등록하는 UseCase를 구현하였습니다.
- Achievement를 등록하는 ViewModel을 구현하였습니다.

## Note
ViewModel 테스트에서 다른 UseCase를 주입해야 하는 경우, 테스트 메서드 내부에서 생성을 해야할지 고민입니다.
생성 메서드를 따로 구현할까도 생각이 들지만.. 근본적인 해결책은 아닌 거 같아서 고민이 드네요.
Dependency라는 구조체를 주입 받는다면 이런 현상이 완화될까요? 🤔
Dependency 모델 정의도 시도해봐야겠습니다.

## Issue
closed #112 
