### PR TITLE
[#116] 도전기록 리스트가 잘못 표시되는 문제 수정

### DIFF
--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		9B95D92F2BF0C7CE003BFDC3 /* AutoLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D92E2BF0C7CE003BFDC3 /* AutoLoginUseCase.swift */; };
 		9B95D9322BF21995003BFDC3 /* AchievementRequestValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D9312BF21995003BFDC3 /* AchievementRequestValue.swift */; };
 		9B95D9342BF22E47003BFDC3 /* AddAchievementUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D9332BF22E47003BFDC3 /* AddAchievementUseCase.swift */; };
+		9B95D93C2BF44D34003BFDC3 /* NSDirectionalEdgeInsets+init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D93B2BF44D34003BFDC3 /* NSDirectionalEdgeInsets+init.swift */; };
+		9B95D93E2BF44D7F003BFDC3 /* NSCollectionLayoutEdgeSpacing+init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D93D2BF44D7F003BFDC3 /* NSCollectionLayoutEdgeSpacing+init.swift */; };
 		9BA895872BDFDB5B0080D400 /* JeongDesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 9BA895862BDFDB5B0080D400 /* JeongDesignSystem */; };
 		9BA8958C2BE11C820080D400 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA8958B2BE11C820080D400 /* HomeViewModelTests.swift */; };
 		9BA895992BE387870080D400 /* AchievementRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895982BE387870080D400 /* AchievementRepositoryTests.swift */; };
@@ -157,6 +159,8 @@
 		9B95D92E2BF0C7CE003BFDC3 /* AutoLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLoginUseCase.swift; sourceTree = "<group>"; };
 		9B95D9312BF21995003BFDC3 /* AchievementRequestValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRequestValue.swift; sourceTree = "<group>"; };
 		9B95D9332BF22E47003BFDC3 /* AddAchievementUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAchievementUseCase.swift; sourceTree = "<group>"; };
+		9B95D93B2BF44D34003BFDC3 /* NSDirectionalEdgeInsets+init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSDirectionalEdgeInsets+init.swift"; sourceTree = "<group>"; };
+		9B95D93D2BF44D7F003BFDC3 /* NSCollectionLayoutEdgeSpacing+init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSCollectionLayoutEdgeSpacing+init.swift"; sourceTree = "<group>"; };
 		9BA8958B2BE11C820080D400 /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
 		9BA895982BE387870080D400 /* AchievementRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepositoryTests.swift; sourceTree = "<group>"; };
 		9BA8959A2BE38CCA0080D400 /* AchievementRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRepository.swift; sourceTree = "<group>"; };
@@ -593,6 +597,8 @@
 			children = (
 				9BA895D62BE750A60080D400 /* UICollectionReusableView+identifier.swift */,
 				9BA895D82BE750C30080D400 /* UICollectionView+Register.swift */,
+				9B95D93B2BF44D34003BFDC3 /* NSDirectionalEdgeInsets+init.swift */,
+				9B95D93D2BF44D7F003BFDC3 /* NSCollectionLayoutEdgeSpacing+init.swift */,
 			);
 			path = CollectionView;
 			sourceTree = "<group>";
@@ -742,6 +748,7 @@
 				9B289C7B2BDCF0E0000813C1 /* LayoutViewController.swift in Sources */,
 				9BA8959F2BE38D6A0080D400 /* Achievement.swift in Sources */,
 				9B411CBF2BDFD0A700A50B78 /* HomeViewController.swift in Sources */,
+				9B95D93C2BF44D34003BFDC3 /* NSDirectionalEdgeInsets+init.swift in Sources */,
 				9BA895D42BE74F880080D400 /* CategoryCollectionViewCell.swift in Sources */,
 				9BA895D12BE725D60080D400 /* CompositionalLayout.swift in Sources */,
 				9BA895BA2BE5FBC50080D400 /* FetchCategoriesUseCase.swift in Sources */,
@@ -760,6 +767,7 @@
 				9B289C732BDCDDBD000813C1 /* BaseView.swift in Sources */,
 				9B411CBC2BDFCB9F00A50B78 /* UIView+Combine.swift in Sources */,
 				9B289C772BDCED27000813C1 /* LaunchViewController.swift in Sources */,
+				9B95D93E2BF44D7F003BFDC3 /* NSCollectionLayoutEdgeSpacing+init.swift in Sources */,
 				9B411CC12BDFD0AC00A50B78 /* HomeView.swift in Sources */,
 				9BA895D72BE750A60080D400 /* UICollectionReusableView+identifier.swift in Sources */,
 				9B289C8D2BDE4687000813C1 /* LoginViewController.swift in Sources */,

--- a/RefactorMoti/RefactorMoti/Presentation/Base/CollectionView/CompositionalLayout.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Base/CollectionView/CompositionalLayout.swift
@@ -125,28 +125,3 @@ struct CompositionalLayoutSection {
         return section
     }
 }
-
-
-// MARK: - NSDirectionalEdgeInsets
-
-extension NSDirectionalEdgeInsets {
-    
-    init(inset: CGFloat) {
-        self.init(top: inset, leading: inset, bottom: inset, trailing: inset)
-    }
-}
-
-
-// MARK: - NSCollectionLayoutEdgeSpacing
-
-extension NSCollectionLayoutEdgeSpacing {
-    
-    convenience init(
-        top: NSCollectionLayoutSpacing? = nil,
-        leading: NSCollectionLayoutSpacing? = nil,
-        bottom: NSCollectionLayoutSpacing? = nil,
-        trailing: NSCollectionLayoutSpacing? = nil
-    ) {
-        self.init(leading: leading, top: top, trailing: trailing, bottom: bottom)
-    }
-}

--- a/RefactorMoti/RefactorMoti/Presentation/Base/CollectionView/CompositionalLayout.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Base/CollectionView/CompositionalLayout.swift
@@ -9,17 +9,14 @@ import UIKit
 
 enum CompositionalLayout {
     
-    case vertical
-    case horizontal
-    
-    func configure(
+    static func configure(
         item: CompositionalLayoutItem,
         group: CompositionalLayoutGroup,
         section: CompositionalLayoutSection
     ) -> UICollectionViewCompositionalLayout {
         UICollectionViewCompositionalLayout { (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
             let item = item.configure()
-            let group = group.configure(type: self, item: item)
+            let group = group.configure(item: item)
             return section.configure(group: group)
         }
     }
@@ -57,29 +54,35 @@ struct CompositionalLayoutItem {
 
 struct CompositionalLayoutGroup {
     
+    enum Direction {
+        
+        case vertical
+        case horizontal
+    }
+    
+    let direction: Direction
     let size: NSCollectionLayoutSize
     let count: Int
     let contentInsets: NSDirectionalEdgeInsets?
     let edgeSpacing: NSCollectionLayoutEdgeSpacing?
     
     init(
+        direction: Direction,
         size: NSCollectionLayoutSize,
-        count: Int,
+        count: Int = 1,
         contentInsets: NSDirectionalEdgeInsets? = nil,
         edgeSpacing: NSCollectionLayoutEdgeSpacing? = nil
     ) {
+        self.direction = direction
         self.size = size
         self.count = count
         self.contentInsets = contentInsets
         self.edgeSpacing = edgeSpacing
     }
     
-    func configure(
-        type: CompositionalLayout,
-        item: NSCollectionLayoutItem
-    ) -> NSCollectionLayoutGroup {
+    func configure(item: NSCollectionLayoutItem) -> NSCollectionLayoutGroup {
         let subitems = Array(repeating: item, count: count)
-        let group = type == .vertical
+        let group = direction == .vertical
         ? NSCollectionLayoutGroup.vertical(layoutSize: size, subitems: subitems)
         : NSCollectionLayoutGroup.horizontal(layoutSize: size, subitems: subitems)
         
@@ -104,7 +107,7 @@ struct CompositionalLayoutSection {
     let footer: NSCollectionLayoutBoundarySupplementaryItem?
     
     init(
-        orthogonalScrollingBehavior: UICollectionLayoutSectionOrthogonalScrollingBehavior,
+        orthogonalScrollingBehavior: UICollectionLayoutSectionOrthogonalScrollingBehavior = .none,
         header: NSCollectionLayoutBoundarySupplementaryItem? = nil,
         footer: NSCollectionLayoutBoundarySupplementaryItem? = nil
     ) {
@@ -123,3 +126,27 @@ struct CompositionalLayoutSection {
     }
 }
 
+
+// MARK: - NSDirectionalEdgeInsets
+
+extension NSDirectionalEdgeInsets {
+    
+    init(inset: CGFloat) {
+        self.init(top: inset, leading: inset, bottom: inset, trailing: inset)
+    }
+}
+
+
+// MARK: - NSCollectionLayoutEdgeSpacing
+
+extension NSCollectionLayoutEdgeSpacing {
+    
+    convenience init(
+        top: NSCollectionLayoutSpacing? = nil,
+        leading: NSCollectionLayoutSpacing? = nil,
+        bottom: NSCollectionLayoutSpacing? = nil,
+        trailing: NSCollectionLayoutSpacing? = nil
+    ) {
+        self.init(leading: leading, top: top, trailing: trailing, bottom: bottom)
+    }
+}

--- a/RefactorMoti/RefactorMoti/Presentation/Extension/CollectionView/NSCollectionLayoutEdgeSpacing+init.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Extension/CollectionView/NSCollectionLayoutEdgeSpacing+init.swift
@@ -1,0 +1,20 @@
+//
+//  NSCollectionLayoutEdgeSpacing+init.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 5/15/24.
+//
+
+import UIKit
+
+extension NSCollectionLayoutEdgeSpacing {
+    
+    convenience init(
+        top: NSCollectionLayoutSpacing? = nil,
+        leading: NSCollectionLayoutSpacing? = nil,
+        bottom: NSCollectionLayoutSpacing? = nil,
+        trailing: NSCollectionLayoutSpacing? = nil
+    ) {
+        self.init(leading: leading, top: top, trailing: trailing, bottom: bottom)
+    }
+}

--- a/RefactorMoti/RefactorMoti/Presentation/Extension/CollectionView/NSDirectionalEdgeInsets+init.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Extension/CollectionView/NSDirectionalEdgeInsets+init.swift
@@ -1,0 +1,15 @@
+//
+//  NSDirectionalEdgeInsets+init.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 5/15/24.
+//
+
+import UIKit
+
+extension NSDirectionalEdgeInsets {
+    
+    init(inset: CGFloat) {
+        self.init(top: inset, leading: inset, bottom: inset, trailing: inset)
+    }
+}

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
@@ -29,6 +29,7 @@ final class HomeView: BaseView {
     private(set) lazy var categoriesCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeCategoriesCompositionalLayout())
         collectionView.alwaysBounceVertical = false
+        collectionView.alwaysBounceHorizontal = true
         collectionView.register(CategoryCollectionViewCell.self)
         return collectionView
     }()
@@ -107,40 +108,26 @@ private extension HomeView {
             heightDimension: .fractionalHeight(1)
         )
         let item = CompositionalLayoutItem(size: size)
-        let groupEdgeSpacing = NSCollectionLayoutEdgeSpacing(
-            leading: .fixed(Metric.CategoryItem.groupEdgeSpacing),
-            top: .none, trailing: .none, bottom: .none
-        )
-        let group = CompositionalLayoutGroup(size: size, count: 1, edgeSpacing: groupEdgeSpacing)
+        let groupEdgeSpacing = NSCollectionLayoutEdgeSpacing(leading: .fixed(Metric.CategoryItem.groupEdgeSpacing))
+        let group = CompositionalLayoutGroup(direction: .horizontal, size: size, edgeSpacing: groupEdgeSpacing)
         let section = CompositionalLayoutSection(orthogonalScrollingBehavior: .continuous)
-        return CompositionalLayout.horizontal.configure(
-            item: item,
-            group: group,
-            section: section
-        )
+        return CompositionalLayout.configure(item: item, group: group, section: section)
     }
     
     func makeAchievementCompositionalLayout() -> UICollectionViewCompositionalLayout {
+        let itemCount = Metric.Achievement.itemCount
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0 / Metric.Achievement.itemCount),
+            widthDimension: .fractionalWidth(1.0 / CGFloat(itemCount)),
             heightDimension: .fractionalHeight(1)
         )
-        let inset = Metric.Achievement.itemEdgeInset
-        let item = CompositionalLayoutItem(
-            size: itemSize,
-            contentInsets: NSDirectionalEdgeInsets(top: inset, leading: inset, bottom: inset, trailing: inset)
-        )
+        let item = CompositionalLayoutItem(size: itemSize, contentInsets: .init(inset: Metric.Achievement.itemEdgeInset))
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
+            widthDimension: .fractionalWidth(1),
             heightDimension: itemSize.widthDimension
         )
-        let group = CompositionalLayoutGroup(size: groupSize, count: 3)
-        let section = CompositionalLayoutSection(orthogonalScrollingBehavior: .continuous)
-        return CompositionalLayout.horizontal.configure(
-            item: item,
-            group: group,
-            section: section
-        )
+        let group = CompositionalLayoutGroup(direction: .horizontal, size: groupSize, count: itemCount)
+        let section = CompositionalLayoutSection()
+        return CompositionalLayout.configure(item: item, group: group, section: section)
     }
 }
 
@@ -171,7 +158,7 @@ private extension HomeView {
         enum Achievement {
             
             static let itemEdgeInset = 1.0
-            static let itemCount: CGFloat = Constant.isPhone ? 3 : 7
+            static let itemCount = Constant.isPhone ? 3 : 7
             static let topOffset = 10.0
         }
         


### PR DESCRIPTION
## Overview
도전기록 리스트가 잘못 표시되는 문제를 수정하였습니다.

CompositionalLayout에 대한 잘못된 이해로 레이아웃이 잘못 표시되었고, 이를 수정하였습니다.
- Group의 vertical과 horizontal은 아이템을 수직으로 쌓을건지, 수평으로 쌓을건지 결정하는 속성
- CollectionView의 수평 bounce 스크롤을 활성화하려면 CollectionView의 `alwaysBounceHorizontal`를 true로 설정해야 함

## Issue
closed #116 