### PR TITLE
[#120] FlexLayout, PinLayout 의존성 추가 / LaunchView에 PinLayout 적용

### DIFF
--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		9B95D9342BF22E47003BFDC3 /* AddAchievementUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D9332BF22E47003BFDC3 /* AddAchievementUseCase.swift */; };
 		9B95D93C2BF44D34003BFDC3 /* NSDirectionalEdgeInsets+init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D93B2BF44D34003BFDC3 /* NSDirectionalEdgeInsets+init.swift */; };
 		9B95D93E2BF44D7F003BFDC3 /* NSCollectionLayoutEdgeSpacing+init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95D93D2BF44D7F003BFDC3 /* NSCollectionLayoutEdgeSpacing+init.swift */; };
+		9B95D9412BFB81F9003BFDC3 /* FlexLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 9B95D9402BFB81F9003BFDC3 /* FlexLayout */; };
+		9B95D9442BFB8222003BFDC3 /* PinLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 9B95D9432BFB8222003BFDC3 /* PinLayout */; };
 		9BA895872BDFDB5B0080D400 /* JeongDesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 9BA895862BDFDB5B0080D400 /* JeongDesignSystem */; };
 		9BA8958C2BE11C820080D400 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA8958B2BE11C820080D400 /* HomeViewModelTests.swift */; };
 		9BA895992BE387870080D400 /* AchievementRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895982BE387870080D400 /* AchievementRepositoryTests.swift */; };
@@ -193,8 +195,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B95D9442BFB8222003BFDC3 /* PinLayout in Frameworks */,
 				9B4581742BD7EC40002A32DC /* FirebaseDatabase in Frameworks */,
 				9BA895872BDFDB5B0080D400 /* JeongDesignSystem in Frameworks */,
+				9B95D9412BFB81F9003BFDC3 /* FlexLayout in Frameworks */,
 				9BA895DC2BE7AF820080D400 /* Jeongfisher in Frameworks */,
 				9B95D91D2BEF146A003BFDC3 /* FirebaseAuth in Frameworks */,
 			);
@@ -625,6 +629,8 @@
 				9BA895862BDFDB5B0080D400 /* JeongDesignSystem */,
 				9BA895DB2BE7AF820080D400 /* Jeongfisher */,
 				9B95D91C2BEF146A003BFDC3 /* FirebaseAuth */,
+				9B95D9402BFB81F9003BFDC3 /* FlexLayout */,
+				9B95D9432BFB8222003BFDC3 /* PinLayout */,
 			);
 			productName = RefactorMoti;
 			productReference = 9B45811E2BD52EB7002A32DC /* RefactorMoti.app */;
@@ -681,6 +687,8 @@
 				9B4581722BD7EC40002A32DC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				9BA895852BDFDB5B0080D400 /* XCRemoteSwiftPackageReference "JeongDesignSystem" */,
 				9BA895DA2BE7AF820080D400 /* XCRemoteSwiftPackageReference "Jeongfisher" */,
+				9B95D93F2BFB81F9003BFDC3 /* XCRemoteSwiftPackageReference "FlexLayout" */,
+				9B95D9422BFB8222003BFDC3 /* XCRemoteSwiftPackageReference "PinLayout" */,
 			);
 			productRefGroup = 9B45811F2BD52EB7002A32DC /* Products */;
 			projectDirPath = "";
@@ -1116,6 +1124,22 @@
 				minimumVersion = 10.24.0;
 			};
 		};
+		9B95D93F2BFB81F9003BFDC3 /* XCRemoteSwiftPackageReference "FlexLayout" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/layoutBox/FlexLayout.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.7;
+			};
+		};
+		9B95D9422BFB8222003BFDC3 /* XCRemoteSwiftPackageReference "PinLayout" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/layoutBox/PinLayout";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.10.5;
+			};
+		};
 		9BA895852BDFDB5B0080D400 /* XCRemoteSwiftPackageReference "JeongDesignSystem" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jeongju9216/JeongDesignSystem.git";
@@ -1144,6 +1168,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9B4581722BD7EC40002A32DC /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAuth;
+		};
+		9B95D9402BFB81F9003BFDC3 /* FlexLayout */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9B95D93F2BFB81F9003BFDC3 /* XCRemoteSwiftPackageReference "FlexLayout" */;
+			productName = FlexLayout;
+		};
+		9B95D9432BFB8222003BFDC3 /* PinLayout */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9B95D9422BFB8222003BFDC3 /* XCRemoteSwiftPackageReference "PinLayout" */;
+			productName = PinLayout;
 		};
 		9BA895862BDFDB5B0080D400 /* JeongDesignSystem */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/RefactorMoti/RefactorMoti.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b7ea6d6c899f0e373f6e39eab685a90cdb17f6af110e8f955c6bf1cef6466db5",
+  "originHash" : "043362e2884b77f840bbaf5febb96b55ddd46ac6625961695fbd674ac19c5644",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "97940381e57703c07f31a8058d8f39ec53b7c272",
         "version" : "10.25.0"
+      }
+    },
+    {
+      "identity" : "flexlayout",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/layoutBox/FlexLayout.git",
+      "state" : {
+        "revision" : "ad20f2874f0fe87300e89caed2f03d5c9525c3c0",
+        "version" : "2.0.7"
       }
     },
     {
@@ -116,6 +125,15 @@
       "state" : {
         "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
         "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "pinlayout",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/layoutBox/PinLayout",
+      "state" : {
+        "revision" : "8eaa3a15e4dcabaca4c95aea4c0ff0c9b4a67213",
+        "version" : "1.10.5"
       }
     },
     {

--- a/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Launch/LaunchView.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import PinLayout
 
 final class LaunchView: BaseView {
     
@@ -13,6 +14,7 @@ final class LaunchView: BaseView {
     
     func update(currentVersion: String) {
         versionLabel.text = currentVersion
+        versionLabel.pin.sizeToFit()
     }
     
     
@@ -30,21 +32,23 @@ final class LaunchView: BaseView {
     }()
     
     
+    // MARK: - Life Cycle
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+     
+        motiIconImageView.pin.center().size(Size.appIconRound)
+        versionLabel.pin.bottom(pin.safeArea).hCenter()
+            .marginBottom(Metric.VersionLabel.bottomOffset)
+            .sizeToFit()
+    }
+    
+    
     // MARK: - Setup
     
     override func setUpSubview() {
         addSubview(motiIconImageView)
         addSubview(versionLabel)
-    }
-    
-    override func setUpConstraint() {
-        motiIconImageView.atl
-            .size(Size.appIconRound)
-            .center(equalTo: safeAreaLayoutGuide)
-        
-        versionLabel.atl
-            .centerX(equalTo: safeAreaLayoutGuide.centerXAnchor)
-            .bottom(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Metric.VersionLabel.bottomOffset)
     }
 }
 


### PR DESCRIPTION
## Overview
- FlexLayout과 PinLayout 의존성을 추가했습니다.
- LaunchView에 PinLayout을 적용했습니다.

## Note
FlexLayout은 개선된 UIStackView 구조입니다.
LaunchView는 Stack 구조가 불필요하여 PinLayout만으로 충분했습니다.
억지로 FlexLayout을 쓰려고 해봤지만, 코드가 명확하지 않아 보였습니다. (제가 혼자 어색해하는걸 수 있음)
조금 더 익숙해지기 위해 연습이 필요함을 느꼈습니다.

추가로, versionLabel의 text가 바뀔 때 Label의 크기가 변하지 않았습니다.
이 문제를 해결하기 위해 pin.sizeToFit()을 호출해주고 있는데 이게 맞는 방식인지 헷갈리네요.
이부분도 추가 학습이 필요할 거 같습니다.

## Screenshot
<img src = "https://github.com/jeongju9216/moti-2.0/assets/89075274/72a7b6be-5b9f-4e3e-b2cd-95c1a28b7abb" width = "40%">

## Issue
closed #120 