### PR TITLE
[#126] 홈 화면에 PinLayout과 FlexLayout을 적용한다.

### DIFF
--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 import JeongDesignSystem
+import FlexLayout
+import PinLayout
 
 final class HomeView: BaseView {
     
@@ -26,6 +28,7 @@ final class HomeView: BaseView {
     
     // MARK: - UI
     
+    private let flexBox = UIView()
     private(set) lazy var categoriesCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeCategoriesCompositionalLayout())
         collectionView.alwaysBounceVertical = false
@@ -62,38 +65,30 @@ final class HomeView: BaseView {
     }()
     
     
+    // MARK: - Life Cycle
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        flexBox.pin.all(pin.safeArea)
+        flexBox.flex.layout()
+    }
+    
+    
     // MARK: - Setup
     
     override func setUpSubview() {
-        addSubview(addCategoryButton)
-        addSubview(separatorView)
-        addSubview(categoriesCollectionView)
-        addSubview(achievementCollectionView)
-        addSubview(addAchievementButton)
+        addSubview(flexBox)
     }
     
     override func setUpConstraint() {
-        addCategoryButton.atl
-            .width(equalTo: addCategoryButton.heightAnchor)
-            .height(Metric.CategoryList.height)
-            .top(equalTo: safeAreaLayoutGuide.topAnchor, constant: Metric.CategoryList.topOffset)
-            .left(equalTo: safeAreaLayoutGuide.leftAnchor, constant: Metric.AddCategoryButton.horizontalOffset)
-            .right(equalTo: separatorView.leftAnchor, constant: -Metric.AddCategoryButton.horizontalOffset)
-        separatorView.atl
-            .width(1)
-            .height(Metric.CategoryList.height)
-            .top(equalTo: safeAreaLayoutGuide.topAnchor, constant: Metric.CategoryList.topOffset)
-            .right(equalTo: categoriesCollectionView.leftAnchor)
-        categoriesCollectionView.atl
-            .height(Metric.CategoryList.height)
-            .top(equalTo: safeAreaLayoutGuide.topAnchor, constant: Metric.CategoryList.topOffset)
-            .right(equalTo: safeAreaLayoutGuide.rightAnchor)
-        achievementCollectionView.atl
-            .top(equalTo: categoriesCollectionView.bottomAnchor, constant: Metric.Achievement.topOffset)
-            .bottom(equalTo: self.bottomAnchor)
-            .horizontal(equalTo: safeAreaLayoutGuide)
-        addAchievementButton.atl
-            .center(equalTo: self)
+        flexBox.flex.direction(.column).define { flex in
+            flex.direction(.row).height(Metric.CategoryList.height).marginTop(Metric.CategoryList.topOffset).define { flex in
+                flex.addItem(addCategoryButton).width(Metric.CategoryList.height).marginHorizontal(Metric.AddCategoryButton.horizontalOffset)
+                flex.addItem(separatorView).width(1)
+                flex.addItem(categoriesCollectionView).grow(1)
+            }
+        }
     }
 }
 

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
@@ -48,11 +48,6 @@ final class HomeView: BaseView {
         button.jd.cornerRadius(.small)
         return button
     }()
-    private let separatorView: UIView = {
-        let view = UIView()
-        view.backgroundColor = Color.AddCategoryButton.separator
-        return view
-    }()
     
     // TODO: 임시 도전기록 추가 버튼입니다.
     private let addAchievementButton: UIButton = {
@@ -82,12 +77,14 @@ final class HomeView: BaseView {
     }
     
     override func setUpConstraint() {
-        flexBox.flex.direction(.column).define { flex in
-            flex.direction(.row).height(Metric.CategoryList.height).marginTop(Metric.CategoryList.topOffset).define { flex in
+        flexBox.flex.define { flex in
+            flex.addItem().direction(.row).height(Metric.CategoryList.height).marginTop(Metric.CategoryList.topOffset).define { flex in
                 flex.addItem(addCategoryButton).width(Metric.CategoryList.height).marginHorizontal(Metric.AddCategoryButton.horizontalOffset)
-                flex.addItem(separatorView).width(1)
+                flex.addItem().width(1).backgroundColor(Color.AddCategoryButton.separator)
                 flex.addItem(categoriesCollectionView).grow(1)
             }
+            
+            flex.addItem(achievementCollectionView).marginTop(Metric.Achievement.topOffset).grow(1)
         }
     }
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
@@ -65,7 +65,7 @@ final class HomeView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        flexBox.pin.all(pin.safeArea)
+        flexBox.pin.top(pin.safeArea).bottom().horizontally(pin.safeArea)
         flexBox.flex.layout()
     }
     


### PR DESCRIPTION
## Overview
홈 화면의 카테고리 리스트와 도전기록 리스트를 PinLayout과 FlexLayout으로 구현했습니다.
카테고리 추가 버튼과 카테고리 리스트 UI를 하나의 가로 FlexBox로 묶고,
카테고리 FlexBox와 도전기록 리스트를 세로로 묶었습니다.

## Screenshot
<img src = "https://github.com/jeongju9216/moti-2.0/assets/89075274/9fd4e136-b3a3-4af1-a1b1-e37203ebeea7" width = "40%">

## Issue
closed #126