### PR TITLE
[#131] 홈 화면에 촬영 시작 버튼을 표시한다.

### DIFF
--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
@@ -73,6 +73,7 @@ final class HomeView: BaseView {
     
     override func setUpSubview() {
         addSubview(flexBox)
+        addSubview(addAchievementButton)
     }
     
     override func setUpConstraint() {
@@ -84,7 +85,6 @@ final class HomeView: BaseView {
             }
             
             flex.addItem(achievementCollectionView).marginTop(Metric.Achievement.topOffset).grow(1)
-            flex.addItem(addAchievementButton)
         }
     }
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Home/HomeView.swift
@@ -48,15 +48,12 @@ final class HomeView: BaseView {
         button.jd.cornerRadius(.small)
         return button
     }()
-    
-    // TODO: 임시 도전기록 추가 버튼입니다.
     private let addAchievementButton: UIButton = {
-        var configuration = UIButton.Configuration.plain()
-        configuration.title = "Achievement 파이어베이스 추가"
-        configuration.baseForegroundColor = .red
-        let button = UIButton(configuration: configuration)
-        button.jd.cornerRadius(.small)
-        return button
+        var configuration = UIButton.Configuration.filled()
+        configuration.background.backgroundColor = JDColor.primary
+        configuration.cornerStyle = .capsule
+        configuration.title = Text.AchievementButton.title
+        return UIButton(configuration: configuration)
     }()
     
     
@@ -67,6 +64,8 @@ final class HomeView: BaseView {
         
         flexBox.pin.top(pin.safeArea).bottom().horizontally(pin.safeArea)
         flexBox.flex.layout()
+        
+        addAchievementButton.pin.bottom(pin.safeArea).hCenter().size(Metric.AchievementButton.size)
     }
     
     
@@ -85,6 +84,7 @@ final class HomeView: BaseView {
             }
             
             flex.addItem(achievementCollectionView).marginTop(Metric.Achievement.topOffset).grow(1)
+            flex.addItem(addAchievementButton)
         }
     }
 }
@@ -163,6 +163,12 @@ private extension HomeView {
             
             static let horizontalOffset = 5.0
         }
+        
+        enum AchievementButton {
+            
+            static let bottomOffset = 10.0
+            static let size = CGSize(width: 180, height: 60)
+        }
     }
     
     enum Text {
@@ -170,6 +176,11 @@ private extension HomeView {
         enum AddCategoryButton {
             
             static let title = "+"
+        }
+        
+        enum AchievementButton {
+            
+            static let title = "도전"
         }
     }
     


### PR DESCRIPTION
## Overview
홈 화면에 촬영 시작 버튼을 표시하였습니다.
이벤트 연결은 수정하지 않았습니다. 그래서 촬영 시작 버튼을 누르면 도전 기록이 추가됩니다 ㄴㅇOㅇㄱ

## Note
아직 FlexLayout과 PinLayout이 익숙하지 않다는걸 느꼈습니다.
FlexLayout에 매몰되어 있고 PinLayout은 기피하고 있어요.

최대한 FlexLayout을 사용해야 하는건지, PinLayout이 쉬운거면 PinLayout으로 잡는건지,
스택뷰 형태일 때만 FlexLayout을 쓰는건지 좀 헷갈리네요.

공식 문서, 여러 블로그와 코드를 살펴보고 있는데 저에게 맞는 케이스가 무엇인지 확 와닿진 않습니다.
저의 이해 곡선은 보통 계단식이어서 이번에도 포기하지 말고 꾸준히 노력해야겠습니다.

## Screenshot
<img src = "https://github.com/jeongju9216/moti-2.0/assets/89075274/07473795-7c70-4267-b8cd-e3a1a2c67b76" width = "40%">

![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-05-24 at 23 05 51](https://github.com/jeongju9216/moti-2.0/assets/89075274/8e848b5d-4c8b-44a1-8891-3cc76ae99aa0)


## Issue
closed #131 
