### PR TITLE
[#132] 촬영 화면 UI를 구현한다. + Known Issue

### DIFF
--- a/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
+++ b/RefactorMoti/RefactorMoti.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		9BA895E22BE875360080D400 /* AddCategoryUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA895E12BE875360080D400 /* AddCategoryUseCaseTests.swift */; };
 		9BE3B4772C01D90B00E3F884 /* CaptureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE3B4762C01D90B00E3F884 /* CaptureViewController.swift */; };
 		9BE3B4792C01D91800E3F884 /* CaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE3B4782C01D91800E3F884 /* CaptureView.swift */; };
+		9BE3B47B2C02CBBC00E3F884 /* CaptureButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE3B47A2C02CBBC00E3F884 /* CaptureButton.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -198,6 +199,7 @@
 		9BA895E12BE875360080D400 /* AddCategoryUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCategoryUseCaseTests.swift; sourceTree = "<group>"; };
 		9BE3B4762C01D90B00E3F884 /* CaptureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureViewController.swift; sourceTree = "<group>"; };
 		9BE3B4782C01D91800E3F884 /* CaptureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureView.swift; sourceTree = "<group>"; };
+		9BE3B47A2C02CBBC00E3F884 /* CaptureButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -650,6 +652,7 @@
 			children = (
 				9BE3B4762C01D90B00E3F884 /* CaptureViewController.swift */,
 				9BE3B4782C01D91800E3F884 /* CaptureView.swift */,
+				9BE3B47A2C02CBBC00E3F884 /* CaptureButton.swift */,
 			);
 			path = Capture;
 			sourceTree = "<group>";
@@ -816,6 +819,7 @@
 				9B411CB32BDFC31F00A50B78 /* LoginViewModel.swift in Sources */,
 				9B45812C2BD52EB7002A32DC /* RefactorMoti.xcdatamodeld in Sources */,
 				9B4581222BD52EB7002A32DC /* AppDelegate.swift in Sources */,
+				9BE3B47B2C02CBBC00E3F884 /* CaptureButton.swift in Sources */,
 				9B95D9292BF0C006003BFDC3 /* UserRepositoryProtocol.swift in Sources */,
 				9BA8959D2BE38CDA0080D400 /* AchievementRepositoryProtocol.swift in Sources */,
 				9B95D92F2BF0C7CE003BFDC3 /* AutoLoginUseCase.swift in Sources */,

--- a/RefactorMoti/RefactorMoti/Presentation/Screen/Capture/CaptureButton.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Screen/Capture/CaptureButton.swift
@@ -1,0 +1,121 @@
+//
+//  CaptureButton.swift
+//  RefactorMoti
+//
+//  Created by 유정주 on 5/26/24.
+//
+
+import UIKit
+import JeongDesignSystem
+import PinLayout
+
+final class CaptureButton: UIButton {
+
+    // MARK: - UI
+    
+    private let circleView: UIView = {
+        let view = UIView()
+        view.isUserInteractionEnabled = false
+        view.backgroundColor = Color.button
+        view.layer.cornerRadius = Metric.smallSize.width / 2
+        return view
+    }()
+    
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect = .zero) {
+        super.init(frame: frame)
+        
+        setUpAttributes()
+        setUpActions()
+        setUpSubviews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    // MARK: - Life Cycle
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        pin.size(Metric.size)
+        circleView.pin.size(Metric.smallSize).center()
+    }
+    
+    
+    // MARK: - Setup
+    
+    private func setUpAttributes() {
+        backgroundColor = JDColor.background
+        layer.borderColor = Color.button.cgColor
+        layer.borderWidth = Metric.borderWidth
+        layer.cornerRadius = Metric.size.width / 2
+    }
+    
+    private func setUpActions() {
+        addTarget(self, action: #selector(didTouchDown), for: .touchDown)
+        addTarget(self, action: #selector(didTouchUpInside), for: .touchUpInside)
+        addTarget(self, action: #selector(didTouchUpOutside), for: .touchUpOutside)
+    }
+    
+    private func setUpSubviews() {
+        addSubview(circleView)
+    }
+}
+
+
+// MARK: - Action
+
+private extension CaptureButton {
+    
+    @objc
+    func didTouchDown() {
+        UIView.animate(withDuration: Animation.duration) {
+            let scale = CGAffineTransform(scaleX: Animation.touchDownScale, y: Animation.touchDownScale)
+            self.circleView.transform = scale
+        }
+    }
+    
+    @objc
+    func didTouchUpInside() {
+        UIView.animate(withDuration: Animation.duration) {
+            self.circleView.transform = .identity
+        }
+    }
+    
+    @objc
+    func didTouchUpOutside() {
+        UIView.animate(withDuration: Animation.duration) {
+            self.circleView.transform = .identity
+        }
+    }
+}
+
+
+// MARK: - Constant
+
+private extension CaptureButton {
+    
+    enum Metric {
+        
+        static let size = CGSize(width: 75, height: 75)
+        static let smallSize = CGSize(width: 60, height: 60)
+        static let borderWidth = 6.0
+    }
+    
+    enum Color {
+        
+        static let button = JDColor.primary
+    }
+    
+    enum Animation {
+        
+        static let duration = 0.2
+        static let touchDownScale = 0.9
+    }
+}
+

--- a/RefactorMoti/RefactorMoti/Presentation/Screen/Capture/CaptureView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Screen/Capture/CaptureView.swift
@@ -37,7 +37,7 @@ final class CaptureView: BaseView {
     private let captureButton = CaptureButton()
     private let cameraSwitchingButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
-        configuration.image = UIImage(systemName: Image.cameraBack)
+        configuration.image = UIImage(systemName: Image.cameraSwitching)
         configuration.preferredSymbolConfigurationForImage = .init(pointSize: Size.buttonPointSize, weight: .bold)
         configuration.baseForegroundColor = JDColor.darkGray
         return UIButton(configuration: configuration)
@@ -98,7 +98,6 @@ private extension CaptureView {
         
         static let close = "xmark.circle"
         static let album = "photo"
-        static let cameraFront = "iphone"
-        static let cameraBack = "iphone.rear.camera"
+        static let cameraSwitching = "arrow.triangle.2.circlepath.camera"
     }
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Screen/Capture/CaptureView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Screen/Capture/CaptureView.swift
@@ -22,6 +22,11 @@ final class CaptureView: BaseView {
         configuration.baseForegroundColor = JDColor.darkGray
         return UIButton(configuration: configuration)
     }()
+    private let previewView: UIView = {
+        let view = UIView()
+        view.backgroundColor = JDColor.gray
+        return view
+    }()
     
     
     // MARK: - Life Cycle
@@ -30,6 +35,7 @@ final class CaptureView: BaseView {
         super.layoutSubviews()
         flexBox.pin.all(pin.safeArea)
         flexBox.flex.layout()
+        previewView.pin.hCenter().vCenter(-Size.close.height)
     }
     
     
@@ -43,9 +49,13 @@ final class CaptureView: BaseView {
     override func setUpConstraint() {
         super.setUpConstraint()
         flexBox.flex.define { flex in
-            flex.direction(.row).define { flex in
+            flex.addItem().direction(.row).define { flex in
                 flex.addItem().grow(1)
                 flex.addItem(closeButton).size(Size.close)
+            }
+            
+            flex.addItem().grow(1).define { flex in
+                flex.addItem(previewView).width(100%).aspectRatio(1)
             }
         }
     }

--- a/RefactorMoti/RefactorMoti/Presentation/Screen/Capture/CaptureView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Screen/Capture/CaptureView.swift
@@ -27,6 +27,7 @@ final class CaptureView: BaseView {
         view.backgroundColor = JDColor.gray
         return view
     }()
+    private let captureButton = CaptureButton()
     
     
     // MARK: - Life Cycle
@@ -57,6 +58,12 @@ final class CaptureView: BaseView {
             flex.addItem().grow(1).define { flex in
                 flex.addItem(previewView).width(100%).aspectRatio(1)
             }
+            
+            flex.addItem().direction(.row).justifyContent(.spaceAround).alignItems(.center).define { flex in
+                flex.addItem().backgroundColor(.red).size(Size.close)
+                flex.addItem(captureButton).size(Size.capture)
+                flex.addItem().backgroundColor(.red).size(Size.close)
+            }
         }
     }
 }
@@ -70,6 +77,7 @@ private extension CaptureView {
         
         static let closePointSize = 21.0
         static let close = CGSize(width: 44, height: 44)
+        static let capture = CGSize(width: 75, height: 75)
     }
     
     enum Image {

--- a/RefactorMoti/RefactorMoti/Presentation/Screen/Capture/CaptureView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Screen/Capture/CaptureView.swift
@@ -6,17 +6,21 @@
 //
 
 import UIKit
+import FlexLayout
 import PinLayout
+import JeongDesignSystem
 
 final class CaptureView: BaseView {
     
     // MARK: - UI
     
-    private let label: UILabel = {
-        let label = UILabel()
-        label.text = "Capture"
-        label.textAlignment = .center
-        return label
+    private let flexBox = UIView()
+    private let closeButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(systemName: Image.close)
+        configuration.preferredSymbolConfigurationForImage =  .init(pointSize: Size.closePointSize, weight: .bold)
+        configuration.baseForegroundColor = JDColor.darkGray
+        return UIButton(configuration: configuration)
     }()
     
     
@@ -24,8 +28,8 @@ final class CaptureView: BaseView {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        
-        label.pin.all()
+        flexBox.pin.all(pin.safeArea)
+        flexBox.flex.layout()
     }
     
     
@@ -33,6 +37,33 @@ final class CaptureView: BaseView {
     
     override func setUpSubview() {
         super.setUpSubview()
-        addSubview(label)
+        addSubview(flexBox)
+    }
+    
+    override func setUpConstraint() {
+        super.setUpConstraint()
+        flexBox.flex.define { flex in
+            flex.direction(.row).define { flex in
+                flex.addItem().grow(1)
+                flex.addItem(closeButton).size(Size.close)
+            }
+        }
+    }
+}
+
+
+// MARK: - Constant
+
+private extension CaptureView {
+    
+    enum Size {
+        
+        static let closePointSize = 21.0
+        static let close = CGSize(width: 44, height: 44)
+    }
+    
+    enum Image {
+        
+        static let close = "xmark.circle"
     }
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Screen/Capture/CaptureView.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Screen/Capture/CaptureView.swift
@@ -18,7 +18,7 @@ final class CaptureView: BaseView {
     private let closeButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
         configuration.image = UIImage(systemName: Image.close)
-        configuration.preferredSymbolConfigurationForImage =  .init(pointSize: Size.closePointSize, weight: .bold)
+        configuration.preferredSymbolConfigurationForImage = .init(pointSize: Size.buttonPointSize, weight: .bold)
         configuration.baseForegroundColor = JDColor.darkGray
         return UIButton(configuration: configuration)
     }()
@@ -27,7 +27,21 @@ final class CaptureView: BaseView {
         view.backgroundColor = JDColor.gray
         return view
     }()
+    private let albumButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(systemName: Image.album)
+        configuration.preferredSymbolConfigurationForImage = .init(pointSize: Size.buttonPointSize, weight: .bold)
+        configuration.baseForegroundColor = JDColor.darkGray
+        return UIButton(configuration: configuration)
+    }()
     private let captureButton = CaptureButton()
+    private let cameraSwitchingButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(systemName: Image.cameraBack)
+        configuration.preferredSymbolConfigurationForImage = .init(pointSize: Size.buttonPointSize, weight: .bold)
+        configuration.baseForegroundColor = JDColor.darkGray
+        return UIButton(configuration: configuration)
+    }()
     
     
     // MARK: - Life Cycle
@@ -36,7 +50,7 @@ final class CaptureView: BaseView {
         super.layoutSubviews()
         flexBox.pin.all(pin.safeArea)
         flexBox.flex.layout()
-        previewView.pin.hCenter().vCenter(-Size.close.height)
+        previewView.pin.hCenter().vCenter(-Size.systemButton.height)
     }
     
     
@@ -52,7 +66,7 @@ final class CaptureView: BaseView {
         flexBox.flex.define { flex in
             flex.addItem().direction(.row).define { flex in
                 flex.addItem().grow(1)
-                flex.addItem(closeButton).size(Size.close)
+                flex.addItem(closeButton).size(Size.systemButton)
             }
             
             flex.addItem().grow(1).define { flex in
@@ -60,9 +74,9 @@ final class CaptureView: BaseView {
             }
             
             flex.addItem().direction(.row).justifyContent(.spaceAround).alignItems(.center).define { flex in
-                flex.addItem().backgroundColor(.red).size(Size.close)
+                flex.addItem(albumButton).size(Size.systemButton)
                 flex.addItem(captureButton).size(Size.capture)
-                flex.addItem().backgroundColor(.red).size(Size.close)
+                flex.addItem(cameraSwitchingButton).size(Size.systemButton)
             }
         }
     }
@@ -75,13 +89,16 @@ private extension CaptureView {
     
     enum Size {
         
-        static let closePointSize = 21.0
-        static let close = CGSize(width: 44, height: 44)
+        static let buttonPointSize = 21.0
+        static let systemButton = CGSize(width: 44, height: 44)
         static let capture = CGSize(width: 75, height: 75)
     }
     
     enum Image {
         
         static let close = "xmark.circle"
+        static let album = "photo"
+        static let cameraFront = "iphone"
+        static let cameraBack = "iphone.rear.camera"
     }
 }

--- a/RefactorMoti/RefactorMoti/Presentation/Tab/TabBarViewController.swift
+++ b/RefactorMoti/RefactorMoti/Presentation/Tab/TabBarViewController.swift
@@ -79,6 +79,7 @@ private extension TabBarViewController {
     
     func presentCapture() {
         let viewController = CaptureViewController()
+        viewController.modalPresentationStyle = .fullScreen
         present(viewController, animated: true)
     }
 }


### PR DESCRIPTION
## Overview
촬영 화면의 UI를 구현했습니다.

## Known Issue
- 기기를 회전했을 때(width가 더 길어질 때) Preview 영역이 넘치게 잡히는 오류 (https://github.com/jeongju9216/moti-2.0/issues/146)

## Screenshot
<img src = "https://github.com/jeongju9216/moti-2.0/assets/89075274/b746bd59-2cd9-4150-a9f2-bcf199869501" width = "40%">

## Issue
closed #132 